### PR TITLE
feat: add menu item to send ctrl+alt+del

### DIFF
--- a/browser/src/components/menu/keyboard/ctrl-alt-del.tsx
+++ b/browser/src/components/menu/keyboard/ctrl-alt-del.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { SendHorizonal } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { device } from '@/libs/device';
+import { Modifiers } from '@/libs/device/keyboard.ts';
+import { KeyboardCodes } from '@/libs/keyboard';
+
+export const CtrlAltDel = () => {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function ctrlAltDel(): Promise<void> {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    try {
+      const modifiers = new Modifiers();
+      modifiers.leftCtrl = true;
+      modifiers.leftAlt = true;
+      await send(modifiers, KeyboardCodes.get('Delete')!);
+    } catch (e) {
+      console.log(e);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function send(modifiers: Modifiers, code: number) {
+    const keys = [0x00, 0x00, code, 0x00, 0x00, 0x00];
+    await device.sendKeyboardData(modifiers, keys);
+
+    await device.sendKeyboardData(new Modifiers(), [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  }
+
+  return (
+    <div
+      className="flex h-[30px] cursor-pointer items-center space-x-1 rounded px-3 text-neutral-300 hover:bg-neutral-700/60"
+      onClick={ctrlAltDel}
+    >
+      <SendHorizonal size={18} />
+      <span>{t('keyboard.ctrlAltDel')}</span>
+    </div>
+  );
+};

--- a/browser/src/components/menu/keyboard/index.tsx
+++ b/browser/src/components/menu/keyboard/index.tsx
@@ -4,6 +4,7 @@ import { KeyboardIcon } from 'lucide-react';
 
 import { Paste } from './paste.tsx';
 import { VirtualKeyboard } from './virtual-keyboard.tsx';
+import { CtrlAltDel } from './ctrl-alt-del';
 
 export const Keyboard = () => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -11,6 +12,7 @@ export const Keyboard = () => {
   const content = (
     <>
       <Paste />
+      <CtrlAltDel />
       <VirtualKeyboard />
     </>
   );

--- a/browser/src/i18n/locales/en.ts
+++ b/browser/src/i18n/locales/en.ts
@@ -36,7 +36,8 @@ const en = {
     },
     keyboard: {
       paste: 'Paste',
-      virtualKeyboard: 'Keyboard'
+      virtualKeyboard: 'Keyboard',
+      ctrlAltDel: 'Ctrl + Alt + Delete'
     },
     mouse: {
       cursor: {

--- a/browser/src/i18n/locales/ru.ts
+++ b/browser/src/i18n/locales/ru.ts
@@ -36,7 +36,8 @@ const ru = {
     },
     keyboard: {
       paste: 'Вставить текст',
-      virtualKeyboard: 'Виртуальная клавиатура'
+      virtualKeyboard: 'Виртуальная клавиатура',
+      ctrlAltDel: 'Ctrl + Alt + Delete'
     },
     mouse: {
       cursor: {

--- a/browser/src/i18n/locales/zh.ts
+++ b/browser/src/i18n/locales/zh.ts
@@ -34,7 +34,8 @@ const zh = {
     },
     keyboard: {
       paste: '粘贴',
-      virtualKeyboard: '虚拟键盘'
+      virtualKeyboard: '虚拟键盘',
+      ctrlAltDel: 'Ctrl + Alt + Delete'
     },
     mouse: {
       cursor: {

--- a/desktop/src/renderer/src/components/menu/keyboard/ctrl-alt-del.tsx
+++ b/desktop/src/renderer/src/components/menu/keyboard/ctrl-alt-del.tsx
@@ -1,0 +1,40 @@
+import { ReactElement, useState } from 'react'
+import { SendHorizonal } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { IpcEvents } from '@common/ipc-events'
+import { KeyboardCodes } from '@renderer/libs/keyboard'
+
+export const CtrlAltDel = (): ReactElement => {
+  const { t } = useTranslation()
+  const [isLoading, setIsLoading] = useState(false)
+
+  async function ctrlAltDel(): Promise<void> {
+    if (isLoading) return
+    setIsLoading(true)
+
+    try {
+      await send(5, KeyboardCodes.get('Delete')!) // modifier 5 is ctrlLeft + altLeft
+
+      await send(0, 0)
+    } catch (e) {
+      console.log(e)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  async function send(modifier: number, key: number): Promise<void> {
+    await window.electron.ipcRenderer.invoke(IpcEvents.SEND_KEYBOARD, modifier, key)
+  }
+
+  return (
+    <div
+      className="flex h-[30px] cursor-pointer items-center space-x-1 rounded px-3 text-neutral-300 hover:bg-neutral-700/60"
+      onClick={ctrlAltDel}
+    >
+      <SendHorizonal size={18} />
+      <span>{t('keyboard.ctrlAltDel')}</span>
+    </div>
+  )
+}

--- a/desktop/src/renderer/src/components/menu/keyboard/index.tsx
+++ b/desktop/src/renderer/src/components/menu/keyboard/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useState } from 'react'
 import { Popover } from 'antd'
 import { KeyboardIcon } from 'lucide-react'
 
+import { CtrlAltDel } from './ctrl-alt-del'
 import { Paste } from './paste'
 import { VirtualKeyboard } from './virtual-keyboard'
 
@@ -11,6 +12,7 @@ export const Keyboard = (): ReactElement => {
   const content = (
     <>
       <Paste />
+      <CtrlAltDel />
       <VirtualKeyboard />
     </>
   )

--- a/desktop/src/renderer/src/i18n/locales/en.ts
+++ b/desktop/src/renderer/src/i18n/locales/en.ts
@@ -31,7 +31,8 @@ const en = {
     },
     keyboard: {
       paste: 'Paste',
-      virtualKeyboard: 'Keyboard'
+      virtualKeyboard: 'Keyboard',
+      ctrlAltDel: 'Ctrl + Alt + Delete'
     },
     mouse: {
       cursor: {

--- a/desktop/src/renderer/src/i18n/locales/zh.ts
+++ b/desktop/src/renderer/src/i18n/locales/zh.ts
@@ -30,7 +30,8 @@ const zh = {
     },
     keyboard: {
       paste: '粘贴',
-      virtualKeyboard: '虚拟键盘'
+      virtualKeyboard: '虚拟键盘',
+      ctrlAltDel: 'Ctrl + Alt + Delete'
     },
     mouse: {
       cursor: {


### PR DESCRIPTION
The functionality offered is similar to other remote desktop programs (like Microsoft RDP, VMware Horizon). Frequently it is not possible to send a Ctrl+Alt+Delete key combination to the Host, and it is inconvenient to use the virtual keyboard. My solution is a special button to send Ctrl+Alt+Delete