### PR TITLE
feat(desktop): add support for mouse side buttons on macOS w/Logi Options+

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -7,3 +7,6 @@ out
 
 .idea
 .vscode
+
+native/**/build/
+resources/native/*.node

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -22,3 +22,60 @@ pnpm build:mac
 # For Linux
 pnpm build:linux
 ```
+
+## MacOS w/Logi Options+ Mouse Side-Button Support (optional)
+
+On macOS running Logi Options+, the app can optionally forward mouse side
+buttons to the KVM target as `BTN_SIDE`/`BTN_EXTRA` HID reports, driven by a
+native CGEventTap addon in `native/macos/`. **This path is specifically for
+users running Logitech Options+** with the side buttons mapped to back/forward
+navigation — the default rules match the gesture events LO+ emits in that
+configuration.
+
+The app runs fine without this — if the addon isn't built, side-button
+forwarding is silently disabled and everything else works normally.
+
+### Building the addon
+
+Before running `pnpm build:mac`, build the addon against Electron's Node
+headers and drop the `.node` into `resources/`:
+
+```shell
+cd native/macos
+npm install --ignore-scripts
+npx node-gyp rebuild \
+  --target=$(node -e "console.log(require('../../node_modules/electron/package.json').version)") \
+  --arch=arm64 \
+  --dist-url=https://electronjs.org/headers
+cd ../..
+mkdir -p resources/native
+cp native/macos/build/Release/mouse_hook.node resources/native/
+```
+
+### Customizing the rule set
+
+Which events get mapped is driven by a declarative rule file. The shipped
+defaults target Logi Options+ back/forward gestures — see
+[`resources/side-button-rules.default.json`](resources/side-button-rules.default.json)
+for the schema.
+
+To override, drop a `side-button-rules.json` into the app's `userData`
+directory (`~/Library/Application Support/nanokvm-usb/` on macOS):
+
+```json
+[
+  {
+    "name": "My custom rule",
+    "eventType": 29,
+    "fields": [
+      { "field": 132, "equals": 4 },
+      { "field": 115, "equals": [4, 8] }
+    ],
+    "emit": "side"
+  }
+]
+```
+
+Each rule matches a single `CGEventType` plus zero or more field-equality
+checks (integer fields only; `equals` accepts a value or array of values).
+First matching rule wins; non-matching events pass through untouched.

--- a/desktop/native/macos/binding.gyp
+++ b/desktop/native/macos/binding.gyp
@@ -1,0 +1,26 @@
+{
+  "targets": [
+    {
+      "target_name": "mouse_hook",
+      "sources": ["src/mouse_hook.cpp"],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"],
+      "conditions": [
+        ["OS=='mac'", {
+          "xcode_settings": {
+            "MACOSX_DEPLOYMENT_TARGET": "12.0"
+          },
+          "link_settings": {
+            "libraries": [
+              "-framework CoreGraphics",
+              "-framework CoreFoundation",
+              "-framework ApplicationServices"
+            ]
+          }
+        }]
+      ]
+    }
+  ]
+}

--- a/desktop/native/macos/package-lock.json
+++ b/desktop/native/macos/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "nanokvm-mouse-hook",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nanokvm-mouse-hook",
+      "version": "1.0.0",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    }
+  }
+}

--- a/desktop/native/macos/package.json
+++ b/desktop/native/macos/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nanokvm-mouse-hook",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "node-addon-api": "^8.0.0"
+  }
+}

--- a/desktop/native/macos/src/mouse_hook.cpp
+++ b/desktop/native/macos/src/mouse_hook.cpp
@@ -1,0 +1,276 @@
+#include <napi.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <algorithm>
+
+static Napi::ThreadSafeFunction g_tsfn;
+static CFMachPortRef g_eventTap = nullptr;
+static CFRunLoopSourceRef g_runLoopSource = nullptr;
+static CFRunLoopRef g_tapRunLoop = nullptr;
+static std::thread g_tapThread;
+static std::atomic<bool> g_running{false};
+
+// Side-button identifiers emitted to JS (match Linux BTN_SIDE / BTN_EXTRA naming).
+static const int kButtonSide = 0;
+static const int kButtonExtra = 1;
+
+struct FieldMatcher {
+  CGEventField field;
+  std::vector<int64_t> values;  // any-of match
+};
+
+struct Rule {
+  CGEventType eventType;
+  std::vector<FieldMatcher> fields;
+  int button;  // kButtonSide or kButtonExtra
+};
+
+static std::vector<Rule> g_rules;
+static CGEventMask g_eventMask = 0;
+
+struct HookEvent {
+  int kind;    // 0 = status, 1 = button
+  int status;  // for kind == 0
+  int button;  // for kind == 1: kButtonSide or kButtonExtra
+};
+
+static void sendStatus(int status) {
+  HookEvent *he = new HookEvent{0, status, 0};
+  g_tsfn.NonBlockingCall(he, [](Napi::Env env, Napi::Function callback, HookEvent *data) {
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("kind", "status");
+    obj.Set("status", data->status == 0 ? "ok" : "failed");
+    callback.Call({obj});
+    delete data;
+  });
+}
+
+static void sendButton(int button) {
+  HookEvent *he = new HookEvent{1, 0, button};
+  g_tsfn.NonBlockingCall(he, [](Napi::Env env, Napi::Function callback, HookEvent *data) {
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("kind", "button");
+    obj.Set("button", data->button == kButtonExtra ? "extra" : "side");
+    callback.Call({obj});
+    delete data;
+  });
+}
+
+static CGEventRef eventTapCallback(
+    CGEventTapProxy proxy,
+    CGEventType type,
+    CGEventRef event,
+    void *refcon) {
+  (void)proxy;
+  (void)refcon;
+
+  if (type == kCGEventTapDisabledByTimeout || type == kCGEventTapDisabledByUserInput) {
+    if (g_eventTap) {
+      CGEventTapEnable(g_eventTap, true);
+    }
+    return event;
+  }
+
+  for (const auto& rule : g_rules) {
+    if (type != rule.eventType) continue;
+    bool match = true;
+    for (const auto& fm : rule.fields) {
+      int64_t v = CGEventGetIntegerValueField(event, fm.field);
+      if (std::find(fm.values.begin(), fm.values.end(), v) == fm.values.end()) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      sendButton(rule.button);
+      break;  // first match wins
+    }
+  }
+
+  return event;
+}
+
+static bool parseRules(Napi::Env env, Napi::Array arr, std::vector<Rule>& out, CGEventMask& mask) {
+  out.clear();
+  mask = 0;
+
+  for (uint32_t i = 0; i < arr.Length(); i++) {
+    Napi::Value item = arr.Get(i);
+    if (!item.IsObject()) {
+      Napi::TypeError::New(env, "Each rule must be an object").ThrowAsJavaScriptException();
+      return false;
+    }
+    Napi::Object obj = item.As<Napi::Object>();
+
+    if (!obj.Has("eventType") || !obj.Get("eventType").IsNumber()) {
+      Napi::TypeError::New(env, "Rule must have numeric 'eventType'").ThrowAsJavaScriptException();
+      return false;
+    }
+    if (!obj.Has("emit") || !obj.Get("emit").IsString()) {
+      Napi::TypeError::New(env, "Rule must have string 'emit'").ThrowAsJavaScriptException();
+      return false;
+    }
+
+    Rule rule;
+    rule.eventType = (CGEventType)obj.Get("eventType").As<Napi::Number>().Uint32Value();
+
+    std::string emit = obj.Get("emit").As<Napi::String>().Utf8Value();
+    if (emit == "side") {
+      rule.button = kButtonSide;
+    } else if (emit == "extra") {
+      rule.button = kButtonExtra;
+    } else {
+      Napi::TypeError::New(env, "Rule 'emit' must be 'side' or 'extra'").ThrowAsJavaScriptException();
+      return false;
+    }
+
+    if (obj.Has("fields")) {
+      Napi::Value fieldsVal = obj.Get("fields");
+      if (!fieldsVal.IsArray()) {
+        Napi::TypeError::New(env, "Rule 'fields' must be an array").ThrowAsJavaScriptException();
+        return false;
+      }
+      Napi::Array fields = fieldsVal.As<Napi::Array>();
+      for (uint32_t j = 0; j < fields.Length(); j++) {
+        Napi::Value fmVal = fields.Get(j);
+        if (!fmVal.IsObject()) {
+          Napi::TypeError::New(env, "Each field matcher must be an object").ThrowAsJavaScriptException();
+          return false;
+        }
+        Napi::Object fmObj = fmVal.As<Napi::Object>();
+
+        if (!fmObj.Has("field") || !fmObj.Get("field").IsNumber()) {
+          Napi::TypeError::New(env, "Field matcher must have numeric 'field'").ThrowAsJavaScriptException();
+          return false;
+        }
+        if (!fmObj.Has("equals")) {
+          Napi::TypeError::New(env, "Field matcher must have 'equals'").ThrowAsJavaScriptException();
+          return false;
+        }
+
+        FieldMatcher matcher;
+        matcher.field = (CGEventField)fmObj.Get("field").As<Napi::Number>().Uint32Value();
+
+        Napi::Value eq = fmObj.Get("equals");
+        if (eq.IsNumber()) {
+          matcher.values.push_back(eq.As<Napi::Number>().Int64Value());
+        } else if (eq.IsArray()) {
+          Napi::Array eqArr = eq.As<Napi::Array>();
+          for (uint32_t k = 0; k < eqArr.Length(); k++) {
+            Napi::Value v = eqArr.Get(k);
+            if (!v.IsNumber()) {
+              Napi::TypeError::New(env, "'equals' array entries must be numbers").ThrowAsJavaScriptException();
+              return false;
+            }
+            matcher.values.push_back(v.As<Napi::Number>().Int64Value());
+          }
+        } else {
+          Napi::TypeError::New(env, "'equals' must be a number or array of numbers").ThrowAsJavaScriptException();
+          return false;
+        }
+
+        rule.fields.push_back(matcher);
+      }
+    }
+
+    mask |= CGEventMaskBit(rule.eventType);
+    out.push_back(std::move(rule));
+  }
+
+  return true;
+}
+
+static Napi::Value StartHook(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  if (g_running) {
+    Napi::Error::New(env, "Hook is already running").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (info.Length() < 2 || !info[0].IsArray() || !info[1].IsFunction()) {
+    Napi::TypeError::New(env, "Expected (rules: Array, callback: Function)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  std::vector<Rule> rules;
+  CGEventMask mask = 0;
+  if (!parseRules(env, info[0].As<Napi::Array>(), rules, mask)) {
+    return env.Undefined();
+  }
+  if (rules.empty()) {
+    Napi::Error::New(env, "Rules array must not be empty").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  g_rules = std::move(rules);
+  g_eventMask = mask;
+
+  Napi::Function callback = info[1].As<Napi::Function>();
+  g_tsfn = Napi::ThreadSafeFunction::New(env, callback, "MouseHookCallback", 0, 1);
+  g_running = true;
+
+  g_tapThread = std::thread([]() {
+    g_eventTap = CGEventTapCreate(
+        kCGSessionEventTap,
+        kCGHeadInsertEventTap,
+        kCGEventTapOptionListenOnly,
+        g_eventMask,
+        eventTapCallback,
+        nullptr);
+
+    if (!g_eventTap) {
+      sendStatus(1);
+      g_running = false;
+      return;
+    }
+
+    sendStatus(0);
+
+    g_runLoopSource =
+        CFMachPortCreateRunLoopSource(kCFAllocatorDefault, g_eventTap, 0);
+    g_tapRunLoop = CFRunLoopGetCurrent();
+    CFRunLoopAddSource(g_tapRunLoop, g_runLoopSource, kCFRunLoopCommonModes);
+    CGEventTapEnable(g_eventTap, true);
+
+    CFRunLoopRun();
+
+    CGEventTapEnable(g_eventTap, false);
+    CFRelease(g_runLoopSource);
+    CFRelease(g_eventTap);
+    g_eventTap = nullptr;
+    g_runLoopSource = nullptr;
+    g_tapRunLoop = nullptr;
+    g_running = false;
+  });
+
+  return env.Undefined();
+}
+
+static Napi::Value StopHook(const Napi::CallbackInfo &info) {
+  if (!g_running) {
+    return info.Env().Undefined();
+  }
+
+  if (g_tapRunLoop) {
+    CFRunLoopStop(g_tapRunLoop);
+  }
+
+  if (g_tapThread.joinable()) {
+    g_tapThread.join();
+  }
+
+  g_tsfn.Release();
+  return info.Env().Undefined();
+}
+
+static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("startHook", Napi::Function::New(env, StartHook));
+  exports.Set("stopHook", Napi::Function::New(env, StopHook));
+  return exports;
+}
+
+NODE_API_MODULE(mouse_hook, Init)

--- a/desktop/resources/side-button-rules.default.json
+++ b/desktop/resources/side-button-rules.default.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Logi Options+ back gesture",
+    "eventType": 29,
+    "fields": [
+      { "field": 132, "equals": 4 },
+      { "field": 115, "equals": 4 }
+    ],
+    "emit": "side"
+  },
+  {
+    "name": "Logi Options+ forward gesture",
+    "eventType": 29,
+    "fields": [
+      { "field": 132, "equals": 4 },
+      { "field": 115, "equals": 8 }
+    ],
+    "emit": "extra"
+  }
+]

--- a/desktop/src/main/device/index.ts
+++ b/desktop/src/main/device/index.ts
@@ -4,6 +4,8 @@ import { SerialPort } from './serial-port'
 export class Device {
   addr: number
   serialPort: SerialPort
+  private lastAbsX: number = 0
+  private lastAbsY: number = 0
 
   constructor() {
     this.addr = 0x00
@@ -27,9 +29,20 @@ export class Device {
   async sendMouseData(report: number[]): Promise<void> {
     if (report.length === 0) return
 
+    // Absolute reports declare 5 buttons; track last position so side-button
+    // injections from the main process don't teleport the cursor.
+    if (report[0] === 0x02 && report.length >= 7) {
+      this.lastAbsX = report[2] | (report[3] << 8)
+      this.lastAbsY = report[4] | (report[5] << 8)
+    }
+
     const cmdEvent = report[0] === 0x01 ? CmdEvent.SEND_MS_REL_DATA : CmdEvent.SEND_MS_ABS_DATA
     const cmdData = new CmdPacket(this.addr, cmdEvent, report).encode()
     await this.serialPort.write(cmdData)
+  }
+
+  getLastAbsPosition(): { x: number; y: number } {
+    return { x: this.lastAbsX, y: this.lastAbsY }
   }
 }
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { app, BrowserWindow, session, shell } from 'electron'
@@ -5,6 +6,7 @@ import log from 'electron-log/main'
 
 import icon from '../../resources/icon.png?asset'
 import * as events from './events'
+import { device } from './device'
 
 console.error = log.error
 
@@ -33,11 +35,130 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  // Prevent macOS from handling mouse side buttons as browser navigation
+  mainWindow.webContents.on('will-navigate', (event) => {
+    event.preventDefault()
+  })
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.webContents.clearHistory()
+  })
+
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
     mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
   }
+}
+
+type SideButton = 'side' | 'extra'
+
+type FieldMatcher = { field: number; equals: number | number[] }
+
+type SideButtonRule = {
+  name?: string
+  eventType: number
+  fields?: FieldMatcher[]
+  emit: SideButton
+}
+
+type MouseHookEvent =
+  | { kind: 'status'; status: 'ok' | 'failed' }
+  | { kind: 'button'; button: SideButton }
+
+type MouseHook = {
+  startHook: (rules: SideButtonRule[], cb: (event: MouseHookEvent) => void) => void
+  stopHook: () => void
+}
+
+// HID button bits, matching the names Linux uses in input event codes.
+const HID_BIT: Record<SideButton, number> = {
+  side: 0x08,  // BTN_SIDE
+  extra: 0x10  // BTN_EXTRA
+}
+
+function resourcePath(...segments: string[]): string {
+  return app.isPackaged
+    ? join(process.resourcesPath, 'app.asar.unpacked', 'resources', ...segments)
+    : join(__dirname, '../../resources', ...segments)
+}
+
+function loadMouseHook(): MouseHook | null {
+  if (process.platform !== 'darwin') return null
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require(resourcePath('native', 'mouse_hook.node'))
+  } catch (err) {
+    console.error('Failed to load mouse hook native addon:', err)
+    return null
+  }
+}
+
+function loadSideButtonRules(): SideButtonRule[] | null {
+  // User override takes precedence; file location is logged so users can find it.
+  const userPath = join(app.getPath('userData'), 'side-button-rules.json')
+  if (existsSync(userPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(userPath, 'utf8'))
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        log.info(`[mouse-hook] loaded ${parsed.length} rule(s) from ${userPath}`)
+        return parsed
+      }
+      console.error(`[mouse-hook] ${userPath} must be a non-empty array; falling back to defaults`)
+    } catch (err) {
+      console.error(`[mouse-hook] failed to parse ${userPath}; falling back to defaults:`, err)
+    }
+  }
+
+  const defaultPath = resourcePath('side-button-rules.default.json')
+  try {
+    const parsed = JSON.parse(readFileSync(defaultPath, 'utf8'))
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      console.error(`[mouse-hook] default rules file ${defaultPath} is empty or invalid`)
+      return null
+    }
+    return parsed
+  } catch (err) {
+    console.error(`[mouse-hook] failed to load default rules from ${defaultPath}:`, err)
+    return null
+  }
+}
+
+function setupSideButtonForwarding(): void {
+  const mouseHook = loadMouseHook()
+  if (!mouseHook) return
+
+  const rules = loadSideButtonRules()
+  if (!rules) return
+
+  try {
+    mouseHook.startHook(rules, (event) => {
+      if (event.kind === 'status') {
+        if (event.status !== 'ok') console.error(`[mouse-hook] tap status: ${event.status}`)
+        return
+      }
+
+      if (event.kind !== 'button' || !mainWindow?.isFocused()) return
+
+      // Side buttons are only declared on the absolute HID interface (0x02).
+      // Use last known absolute position so we don't teleport the cursor.
+      const hidBit = HID_BIT[event.button]
+      const { x, y } = device.getLastAbsPosition()
+      const x1 = x & 0xff
+      const x2 = (x >> 8) & 0xff
+      const y1 = y & 0xff
+      const y2 = (y >> 8) & 0xff
+      device.sendMouseData([0x02, hidBit, x1, x2, y1, y2, 0])
+        .then(() => device.sendMouseData([0x02, 0, x1, x2, y1, y2, 0]))
+        .catch((err) => console.error('Failed to send side button:', err))
+    })
+  } catch (err) {
+    console.error('[mouse-hook] startHook rejected rules:', err)
+    return
+  }
+
+  app.on('will-quit', () => mouseHook.stopHook())
 }
 
 app.whenReady().then(() => {
@@ -56,6 +177,7 @@ app.whenReady().then(() => {
   events.registerSerialPort()
 
   createWindow()
+  setupSideButtonForwarding()
 
   events.registerUpdater(mainWindow)
 


### PR DESCRIPTION
The use case for this commit is to enable the MacOS version of the app to collect mouse side button events and forward them on through the usb-kvm.

By default, it's configured to collect mouse side button events that are configured as forward/backward navigation events (configured by Logi Options+). But it can be reconfigured to forward select mouse events by modifying a json configuration file.

This change is quite complex because it was made to handle a case where Logi Options+ intercepts the raw HID side-button presses and re-emits them as macOS NSEventTypeGesture events (CGEventType 29), which Chromium does not surface to the renderer as mouse events. This requires significant workarounds.

It is architected into two parts:

(1) The Hook (desktop/native/):

Electron doesn't seem to expose macOS NSEventTypeOtherMouseDown (the AppKit event type that carries button 3/4 back/forward) to the main process JavaScript layer. And if configured via Logi Options+ to be backward/forward events, Chromium consumes those events and doesn't forward them onto the app. Therefore we need a side process to tap into the events and forward them on to the app.

That is what this hook is.

- A C++ N-API addon opens a CGEventTap on kCGSessionEventTap from a dedicated thread running a CFRunLoop.
- The hook itself is generic: it has no hardcoded knowledge of CGEventTypes. startHook(rules, callback) accepts a rules array supplied by the Electron app; each rule specifies a CGEventType, a list of field matchers (field id + any-of values), and which button ('side' or 'extra') to emit on match. The tap callback iterates the rules and, on the first match, emits {kind: 'button', button: 'side' | 'extra'} back to Node via a ThreadSafeFunction.
- The default rule set (loaded from the JSON config in the Electron app) matches CGEventType 29 with phase=ended (field 132) and reads the direction (field 115) to distinguish side vs. extra, which is what Logi Options+ emits for back/forward. The rule config can be edited without rebuilding the native addon.

Note that the build instructions for MacOS get more complicated as we need to build this hook application too as a dependency for the main app. See desktop/README.md.

(2) The Forwarder (desktop/src/main/):

This modifies the electron app to load the hook as an addon and receive events to forward on as HID side-button press+release events.

- index.ts loads the addon (different path in dev vs packaged) and translates each side-button event into an HID press+release.
- The forwarder owns the rule configuration: on startup it reads side-button-rules.json from the user data directory if present, otherwise falls back to the bundled side-button-rules.default.json, and passes the parsed rules array into startHook(). This is what lets users reconfigure which CGEvents map to side/extra without rebuilding the native addon.
- Side buttons are only declared on the device's absolute HID interface (report prefix 0x02); the relative interface (0x01) declares only 3 buttons, so bits 0x08/0x10 sent there are silently dropped by the Linux host. Button presses are always routed through the absolute interface, regardless of which mode the user is in.
- Device.sendMouseData now sniffs outgoing absolute reports and remembers the last x/y, exposed via getLastAbsPosition(), so the injected press doesn't teleport the cursor.