### PR TITLE
feat(desktop): opt-in uncompressed capture mode (sharp video bypassing MJPEG)

### DIFF
--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -7,3 +7,7 @@ out
 
 .idea
 .vscode
+
+# compiled native capture helper (pnpm build:capture)
+resources/nanokvm-capture
+*.tsbuildinfo

--- a/desktop/native/nanokvm-capture.swift
+++ b/desktop/native/nanokvm-capture.swift
@@ -51,7 +51,14 @@ func listCommand() {
 }
 
 final class Writer: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
-  var metaSent = false
+  // The device may deliver a few transitional frames at a stale mode right
+  // after opening — only report META once dimensions are stable, and treat a
+  // later mode change (e.g. the HDMI source resolution changed) as a restart
+  // condition (exit 3) so every emitted frame matches META exactly.
+  var stableW = 0
+  var stableH = 0
+  var stableCount = 0
+  var locked = false
   func captureOutput(_: AVCaptureOutput, didOutput sb: CMSampleBuffer, from _: AVCaptureConnection) {
     guard let pb = CMSampleBufferGetImageBuffer(sb) else { return }
     CVPixelBufferLockBaseAddress(pb, .readOnly)
@@ -63,9 +70,21 @@ final class Writer: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
     let stride = CVPixelBufferGetBytesPerRow(pb)
     let rowBytes = w * 2 // yuvs = 2 bytes/pixel
 
-    if !metaSent {
-      metaSent = true
+    if !locked {
+      if w == stableW && h == stableH {
+        stableCount += 1
+      } else {
+        stableW = w
+        stableH = h
+        stableCount = 1
+      }
+      if stableCount < 3 { return } // drop pre-stable frames
+      locked = true
       FileHandle.standardError.write("META {\"width\":\(w),\"height\":\(h)}\n".data(using: .utf8)!)
+    } else if w != stableW || h != stableH {
+      FileHandle.standardError.write(
+        "ERROR video mode changed (\(stableW)x\(stableH) -> \(w)x\(h))\n".data(using: .utf8)!)
+      exit(3)
     }
 
     if stride == rowBytes {

--- a/desktop/native/nanokvm-capture.swift
+++ b/desktop/native/nanokvm-capture.swift
@@ -1,0 +1,186 @@
+// nanokvm-capture — minimal AVFoundation capture helper for the desktop app's
+// uncompressed video mode. Replaces ffmpeg on macOS: ffmpeg's avfoundation
+// input freezes on large (>=1080p) uncompressed frames, native capture works.
+//
+//   nanokvm-capture list
+//     stdout: one JSON object: {"devices":[{"name":...,"formats":[
+//             {"pixfmt":"yuvs","width":...,"height":...,"fps":[...]}]}]}
+//
+//   nanokvm-capture stream --device <name> --width <w> --height <h> --fps <f>
+//     stderr: one line "META {"width":W,"height":H}" with the ACTUAL delivered
+//             buffer size (the UVC stack may serve the signal-native mode
+//             regardless of the requested format), then raw yuvs (YUY2) frames
+//             on stdout, W*2 bytes per row, tightly packed.
+//
+// SIGINT/SIGTERM stop the session cleanly. Blocking stdout writes provide
+// natural backpressure: late frames are discarded by AVFoundation.
+import AVFoundation
+import Foundation
+
+func fourCC(_ code: FourCharCode) -> String {
+  var s = ""
+  for shift in stride(from: 24, through: 0, by: -8) {
+    s.append(Character(UnicodeScalar(UInt8((code >> UInt32(shift)) & 0xff))))
+  }
+  return s
+}
+
+func discoverDevices() -> [AVCaptureDevice] {
+  AVCaptureDevice.DiscoverySession(
+    deviceTypes: [.external, .builtInWideAngleCamera],
+    mediaType: .video,
+    position: .unspecified
+  ).devices
+}
+
+func listCommand() {
+  var devices: [[String: Any]] = []
+  for d in discoverDevices() {
+    var formats: [[String: Any]] = []
+    for f in d.formats {
+      let dim = CMVideoFormatDescriptionGetDimensions(f.formatDescription)
+      let sub = fourCC(CMFormatDescriptionGetMediaSubType(f.formatDescription))
+      let fps = f.videoSupportedFrameRateRanges.map { $0.maxFrameRate }
+      formats.append(["pixfmt": sub, "width": Int(dim.width), "height": Int(dim.height), "fps": fps])
+    }
+    devices.append(["name": d.localizedName, "formats": formats])
+  }
+  let json = try! JSONSerialization.data(withJSONObject: ["devices": devices])
+  FileHandle.standardOutput.write(json)
+  FileHandle.standardOutput.write("\n".data(using: .utf8)!)
+}
+
+final class Writer: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+  var metaSent = false
+  func captureOutput(_: AVCaptureOutput, didOutput sb: CMSampleBuffer, from _: AVCaptureConnection) {
+    guard let pb = CMSampleBufferGetImageBuffer(sb) else { return }
+    CVPixelBufferLockBaseAddress(pb, .readOnly)
+    defer { CVPixelBufferUnlockBaseAddress(pb, .readOnly) }
+    guard let base = CVPixelBufferGetBaseAddress(pb) else { return }
+
+    let w = CVPixelBufferGetWidth(pb)
+    let h = CVPixelBufferGetHeight(pb)
+    let stride = CVPixelBufferGetBytesPerRow(pb)
+    let rowBytes = w * 2 // yuvs = 2 bytes/pixel
+
+    if !metaSent {
+      metaSent = true
+      FileHandle.standardError.write("META {\"width\":\(w),\"height\":\(h)}\n".data(using: .utf8)!)
+    }
+
+    if stride == rowBytes {
+      if fwrite(base, 1, rowBytes * h, stdout) != rowBytes * h { exit(0) } // EPIPE: consumer gone
+    } else {
+      var p = base
+      for _ in 0..<h {
+        if fwrite(p, 1, rowBytes, stdout) != rowBytes { exit(0) }
+        p += stride
+      }
+    }
+    fflush(stdout)
+  }
+}
+
+func streamCommand(device devName: String, width: Int, height: Int, fps: Double) {
+  guard let device = discoverDevices().first(where: { $0.localizedName == devName }) else {
+    FileHandle.standardError.write("ERROR device not found: \(devName)\n".data(using: .utf8)!)
+    exit(1)
+  }
+
+  // Prefer an exact WxH yuvs format supporting the fps; fall back to any yuvs.
+  let yuvs = device.formats.filter { fourCC(CMFormatDescriptionGetMediaSubType($0.formatDescription)) == "yuvs" }
+  let matching = yuvs.filter {
+    let d = CMVideoFormatDescriptionGetDimensions($0.formatDescription)
+    return Int(d.width) == width && Int(d.height) == height
+  }
+  let format = matching.first(where: { f in
+    f.videoSupportedFrameRateRanges.contains { $0.minFrameRate - 0.5 <= fps && fps <= $0.maxFrameRate + 0.5 }
+  }) ?? matching.first ?? yuvs.first
+  guard let format else {
+    FileHandle.standardError.write("ERROR no yuvs format on \(devName)\n".data(using: .utf8)!)
+    exit(1)
+  }
+
+  signal(SIGPIPE, SIG_IGN)
+
+  let session = AVCaptureSession()
+  guard let input = try? AVCaptureDeviceInput(device: device) else {
+    FileHandle.standardError.write("ERROR cannot open device (permission?)\n".data(using: .utf8)!)
+    exit(1)
+  }
+  session.addInput(input)
+
+  // Set activeFormat AFTER addInput: this flips the session to input-priority
+  // (setting it before is overridden by the default .high preset).
+  do {
+    try device.lockForConfiguration()
+    device.activeFormat = format
+    if let range = format.videoSupportedFrameRateRanges.first(where: {
+      $0.minFrameRate - 0.5 <= fps && fps <= $0.maxFrameRate + 0.5
+    }) {
+      device.activeVideoMinFrameDuration = range.minFrameDuration
+      device.activeVideoMaxFrameDuration = range.maxFrameDuration
+    }
+    device.unlockForConfiguration()
+  } catch {
+    FileHandle.standardError.write("ERROR configure: \(error)\n".data(using: .utf8)!)
+    exit(1)
+  }
+
+  let output = AVCaptureVideoDataOutput()
+  output.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_422YpCbCr8_yuvs]
+  output.alwaysDiscardsLateVideoFrames = true
+  let writer = Writer()
+  output.setSampleBufferDelegate(writer, queue: DispatchQueue(label: "capture"))
+  session.addOutput(output)
+  session.startRunning()
+
+  let stop = { (sig: Int32) -> DispatchSourceSignal in
+    signal(sig, SIG_IGN)
+    let src = DispatchSource.makeSignalSource(signal: sig, queue: .main)
+    src.setEventHandler {
+      session.stopRunning()
+      exit(0)
+    }
+    src.resume()
+    return src
+  }
+  let sigint = stop(SIGINT)
+  let sigterm = stop(SIGTERM)
+  _ = (sigint, sigterm)
+
+  RunLoop.main.run()
+}
+
+// ---- arg parsing ----
+var args = Array(CommandLine.arguments.dropFirst())
+guard let cmd = args.first else {
+  FileHandle.standardError.write("usage: nanokvm-capture list | stream --device <name> --width <w> --height <h> --fps <f>\n".data(using: .utf8)!)
+  exit(2)
+}
+args.removeFirst()
+
+switch cmd {
+case "list":
+  listCommand()
+case "stream":
+  var device = "USB3 Video"
+  var width = 1920
+  var height = 1080
+  var fps = 60.0
+  var i = 0
+  while i < args.count - 1 {
+    switch args[i] {
+    case "--device": device = args[i + 1]
+    case "--width": width = Int(args[i + 1]) ?? width
+    case "--height": height = Int(args[i + 1]) ?? height
+    case "--fps": fps = Double(args[i + 1]) ?? fps
+    default: break
+    }
+    i += 2
+  }
+  streamCommand(device: device, width: width, height: height, fps: fps)
+default:
+  FileHandle.standardError.write("unknown command: \(cmd)\n".data(using: .utf8)!)
+  exit(2)
+}

--- a/desktop/notarize.js
+++ b/desktop/notarize.js
@@ -6,6 +6,11 @@ exports.default = async function notarizing(context) {
     return
   }
 
+  if (!process.env.APPLE_ID || !process.env.APPLE_APP_SPECIFIC_PASSWORD || !process.env.APPLE_TEAM_ID) {
+    console.log('  • skipped notarization: APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID not set')
+    return
+  }
+
   const appName = context.packager.appInfo.productFilename
 
   return await notarize({

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,10 +17,10 @@
     "build:capture": "swiftc -O -o resources/nanokvm-capture native/nanokvm-capture.swift",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
-    "build:mac": "electron-vite build && electron-builder --mac",
+    "build:mac": "npm run build:capture && electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
     "build:win-full": "npm run build && electron-builder --win --x64 --arm64",
-    "build:mac-full": "electron-vite build && electron-builder --mac --x64 --arm64",
+    "build:mac-full": "npm run build:capture && electron-vite build && electron-builder --mac --x64 --arm64",
     "build:linux-full": "electron-vite build && electron-builder --linux --x64 --arm64"
   },
   "dependencies": {
@@ -93,7 +93,7 @@
       "minimatch@<9.0.6": ">=9.0.6",
       "minimatch@>=10.0.0 <10.2.1": ">=10.2.1",
       "tar@<7.5.8": ">=7.5.8",
-      "ajv@<6.14.0": ">=6.14.0",
+      "ajv@<6.14.0": ">=6.14.0 <7",
       "lodash@<4.17.23": ">=4.17.23",
       "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"
     }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,6 +14,7 @@
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
+    "build:capture": "swiftc -O -o resources/nanokvm-capture native/nanokvm-capture.swift",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",

--- a/desktop/src/common/ipc-events.ts
+++ b/desktop/src/common/ipc-events.ts
@@ -6,6 +6,12 @@ export enum IpcEvents {
   REQUEST_MEDIA_PERMISSION = 'request-media-permission',
   SET_FULL_SCREEN = 'set-full-screen',
 
+  GET_CAPTURE_DEVICES = 'get-capture-devices',
+  START_CAPTURE = 'start-capture',
+  STOP_CAPTURE = 'stop-capture',
+  CAPTURE_PORT = 'capture-port',
+  CAPTURE_ERROR = 'capture-error',
+
   GET_SERIAL_PORTS = 'get-serial-ports',
   OPEN_SERIAL_PORT = 'open-serial-port',
   OPEN_SERIAL_PORT_RSP = 'open-serial-port-rsp',

--- a/desktop/src/main/capture/backends.ts
+++ b/desktop/src/main/capture/backends.ts
@@ -1,0 +1,248 @@
+// Platform backends for the uncompressed-capture engine. Each backend
+// enumerates devices/modes and provides the command for a capture process
+// that writes raw yuyv422 (YUY2) frames to stdout.
+//
+//  - macOS: bundled nanokvm-capture Swift helper (native AVFoundation —
+//    ffmpeg's avfoundation input silently freezes on >=1080p uncompressed
+//    frames). Reports the actually-delivered dimensions via a stderr META
+//    line (awaitMeta).
+//  - Windows: system ffmpeg with DirectShow (devices are addressed by name).
+//  - Linux: system ffmpeg with V4L2 (devices are addressed by /dev/videoN).
+import { execFile } from 'child_process'
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+
+import type { Backend, Mode, ResolvedCapture, StreamSpec } from './engine'
+
+function ffmpegPath(): string {
+  const candidates = [
+    process.env.FFMPEG_PATH,
+    '/opt/homebrew/bin/ffmpeg',
+    '/usr/local/bin/ffmpeg',
+    '/usr/bin/ffmpeg',
+    '/snap/bin/ffmpeg'
+  ].filter(Boolean) as string[]
+  return candidates.find((p) => existsSync(p)) || 'ffmpeg'
+}
+
+function execStderr(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile(command, args, (_err, _stdout, stderr) => resolve(stderr || ''))
+  })
+}
+
+const LOW_LATENCY_ARGS = [
+  '-hide_banner',
+  '-loglevel',
+  'error',
+  '-fflags',
+  'nobuffer',
+  '-flags',
+  'low_delay'
+]
+const RAW_OUT_ARGS = ['-pix_fmt', 'yuyv422', '-f', 'rawvideo', '-']
+
+// ---------------------------------------------------------------- macOS ----
+
+const HELPER_CANDIDATES = [
+  process.env.NANOKVM_CAPTURE_PATH,
+  // packaged: resources/ is asarUnpacked (binaries can't execute from asar)
+  join(__dirname, '../../resources/nanokvm-capture').replace('app.asar', 'app.asar.unpacked')
+].filter(Boolean) as string[]
+
+function helperPath(): string {
+  const p = HELPER_CANDIDATES.find((c) => existsSync(c))
+  if (!p) throw new Error('nanokvm-capture helper not found (build it with pnpm build:capture)')
+  return p
+}
+
+type HelperFormat = { pixfmt: string; width: number; height: number; fps: number[] }
+type HelperDevice = { name: string; formats: HelperFormat[] }
+
+function helperList(): Promise<HelperDevice[]> {
+  return new Promise((resolve) => {
+    execFile(helperPath(), ['list'], (_err, stdout) => {
+      try {
+        resolve(JSON.parse(stdout).devices as HelperDevice[])
+      } catch {
+        resolve([])
+      }
+    })
+  })
+}
+
+const darwin: Backend = {
+  async listDevices() {
+    return (await helperList()).map((d) => ({ id: d.name, name: d.name }))
+  },
+
+  async listModes(id: string) {
+    const device = (await helperList()).find((d) => d.name === id)
+    const modes = new Map<string, Mode>()
+    for (const f of device?.formats ?? []) {
+      if (f.pixfmt !== 'yuvs') continue
+      const key = `${f.width}x${f.height}`
+      const mode = modes.get(key) || { width: f.width, height: f.height, fps: [] }
+      for (const v of f.fps) if (v && !mode.fps.includes(v)) mode.fps.push(v)
+      modes.set(key, mode)
+    }
+    return [...modes.values()]
+  },
+
+  streamSpec(r: ResolvedCapture): StreamSpec {
+    return {
+      command: helperPath(),
+      args: [
+        'stream',
+        '--device',
+        r.device,
+        '--width',
+        String(r.width),
+        '--height',
+        String(r.height),
+        '--fps',
+        String(r.fps)
+      ],
+      awaitMeta: true
+    }
+  }
+}
+
+// -------------------------------------------------------------- Windows ----
+
+const dshow: Backend = {
+  async listDevices() {
+    const stderr = await execStderr(ffmpegPath(), [
+      '-hide_banner',
+      '-list_devices',
+      'true',
+      '-f',
+      'dshow',
+      '-i',
+      'dummy'
+    ])
+    const devices: { id: string; name: string }[] = []
+    for (const m of stderr.matchAll(/"(.+?)"\s+\(video\)/g)) {
+      devices.push({ id: m[1], name: m[1] })
+    }
+    return devices
+  },
+
+  async listModes(id: string) {
+    const stderr = await execStderr(ffmpegPath(), [
+      '-hide_banner',
+      '-list_options',
+      'true',
+      '-f',
+      'dshow',
+      '-i',
+      `video=${id}`
+    ])
+    const modes = new Map<string, Mode>()
+    for (const m of stderr.matchAll(/pixel_format=yuyv422.*?max s=(\d+)x(\d+) fps=([\d.]+)/g)) {
+      const width = Number(m[1])
+      const height = Number(m[2])
+      const fps = Number(m[3])
+      const key = `${width}x${height}`
+      const mode = modes.get(key) || { width, height, fps: [] }
+      if (fps && !mode.fps.includes(fps)) mode.fps.push(fps)
+      modes.set(key, mode)
+    }
+    return [...modes.values()]
+  },
+
+  streamSpec(r: ResolvedCapture): StreamSpec {
+    return {
+      command: ffmpegPath(),
+      args: [
+        ...LOW_LATENCY_ARGS,
+        '-f',
+        'dshow',
+        '-rtbufsize',
+        '128M',
+        '-pixel_format',
+        'yuyv422',
+        '-video_size',
+        `${r.width}x${r.height}`,
+        '-framerate',
+        String(r.fps),
+        '-i',
+        `video=${r.device}`,
+        ...RAW_OUT_ARGS
+      ],
+      awaitMeta: false
+    }
+  }
+}
+
+// ---------------------------------------------------------------- Linux ----
+
+const v4l2: Backend = {
+  async listDevices() {
+    let nodes: string[] = []
+    try {
+      nodes = readdirSync('/dev').filter((f) => /^video\d+$/.test(f))
+    } catch {
+      /* no /dev access */
+    }
+    nodes.sort((a, b) => Number(a.slice(5)) - Number(b.slice(5)))
+    return nodes.map((node) => {
+      let name = node
+      try {
+        name = readFileSync(`/sys/class/video4linux/${node}/name`, 'utf8').trim()
+      } catch {
+        /* sysfs name unavailable */
+      }
+      return { id: `/dev/${node}`, name: `${name} (/dev/${node})` }
+    })
+  },
+
+  async listModes(id: string) {
+    // "[video4linux2 ...] Raw : yuyv422 : YUYV 4:2:2 : 640x480 1280x720 ..."
+    const stderr = await execStderr(ffmpegPath(), [
+      '-hide_banner',
+      '-f',
+      'v4l2',
+      '-list_formats',
+      'all',
+      '-i',
+      id
+    ])
+    const modes: Mode[] = []
+    const line = stderr.split('\n').find((l) => l.includes('yuyv422'))
+    if (line) {
+      for (const m of line.matchAll(/(\d+)x(\d+)/g)) {
+        // fps per size isn't listed here; the driver clamps to what it supports
+        modes.push({ width: Number(m[1]), height: Number(m[2]), fps: [] })
+      }
+    }
+    return modes
+  },
+
+  streamSpec(r: ResolvedCapture): StreamSpec {
+    return {
+      command: ffmpegPath(),
+      args: [
+        ...LOW_LATENCY_ARGS,
+        '-f',
+        'v4l2',
+        '-input_format',
+        'yuyv422',
+        '-video_size',
+        `${r.width}x${r.height}`,
+        '-framerate',
+        String(r.fps),
+        '-i',
+        r.device,
+        ...RAW_OUT_ARGS
+      ],
+      awaitMeta: false
+    }
+  }
+}
+
+export function pickBackend(): Backend {
+  if (process.platform === 'darwin') return darwin
+  if (process.platform === 'win32') return dshow
+  return v4l2
+}

--- a/desktop/src/main/capture/engine.ts
+++ b/desktop/src/main/capture/engine.ts
@@ -1,0 +1,270 @@
+// Uncompressed (YUY2/yuvs) capture — macOS Phase 1. Spawns the bundled
+// nanokvm-capture Swift helper (native AVFoundation; ffmpeg's avfoundation
+// input freezes on >=1080p uncompressed frames), assembles exact-size raw
+// frames (O(n) fill buffer — a naive Buffer.concat is O(n^2) and throttles the
+// pipeline), and pushes each frame to the renderer over a MessagePortMain.
+import { ChildProcessWithoutNullStreams, execFile, spawn } from 'child_process'
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { performance } from 'perf_hooks'
+import type { MessagePortMain } from 'electron'
+
+export type CaptureDevice = { index: number; name: string }
+export type CaptureOptions = {
+  deviceIndex?: number
+  width: number
+  height: number
+  fps: number
+  requestId?: number
+}
+export type Mode = { width: number; height: number; fps: number[] }
+// device is the AVFoundation device NAME: indices are not stable — Continuity
+// cameras (iPhone/Desk View) insert and remove themselves and shift the list.
+export type ResolvedCapture = { device: string; width: number; height: number; fps: number }
+
+const HELPER_CANDIDATES = [
+  process.env.NANOKVM_CAPTURE_PATH,
+  join(__dirname, '../../resources/nanokvm-capture')
+].filter(Boolean) as string[]
+
+function helperPath(): string {
+  const p = HELPER_CANDIDATES.find((c) => existsSync(c))
+  if (!p) throw new Error('nanokvm-capture helper not found (build it with pnpm build:capture)')
+  return p
+}
+
+const nowAbs = (): number => performance.timeOrigin + performance.now()
+
+type HelperFormat = { pixfmt: string; width: number; height: number; fps: number[] }
+type HelperDevice = { name: string; formats: HelperFormat[] }
+
+function listAll(): Promise<HelperDevice[]> {
+  return new Promise((resolve) => {
+    execFile(helperPath(), ['list'], (_err, stdout) => {
+      try {
+        resolve(JSON.parse(stdout).devices as HelperDevice[])
+      } catch {
+        resolve([])
+      }
+    })
+  })
+}
+
+/** Enumerate video capture devices. */
+export async function listDevices(): Promise<CaptureDevice[]> {
+  return (await listAll()).map((d, index) => ({ index, name: d.name }))
+}
+
+/** Pick the most likely capture device when the caller doesn't specify one. */
+function autoPick(devices: HelperDevice[]): string {
+  const pref = devices.find(
+    (d) =>
+      /usb|video|capture|hdmi|kvm/i.test(d.name) &&
+      !/facetime|desk view|iphone|capture screen/i.test(d.name)
+  )
+  return (pref || devices[0])?.name ?? ''
+}
+
+/**
+ * Resolve a requested capture to a device + a mode the device advertises.
+ * If the requested resolution isn't offered, fall back to the largest one.
+ * Note the UVC stack may still serve the signal-native mode regardless — the
+ * helper reports the ACTUAL dimensions when the stream starts.
+ */
+export async function resolveCapture(opts: CaptureOptions): Promise<ResolvedCapture> {
+  const devices = await listAll()
+  const byIndex = opts.deviceIndex !== undefined ? devices[opts.deviceIndex] : undefined
+  const device = byIndex ? byIndex.name : autoPick(devices)
+  if (!device) throw new Error('no capture device found')
+
+  const modes = new Map<string, Mode>()
+  for (const f of devices.find((d) => d.name === device)?.formats ?? []) {
+    if (f.pixfmt !== 'yuvs') continue
+    const key = `${f.width}x${f.height}`
+    const mode = modes.get(key) || { width: f.width, height: f.height, fps: [] }
+    for (const v of f.fps) if (v && !mode.fps.includes(v)) mode.fps.push(v)
+    modes.set(key, mode)
+  }
+
+  let { width, height } = opts
+  let mode = modes.get(`${width}x${height}`)
+  if (!mode && modes.size) {
+    mode = [...modes.values()].reduce((a, b) => (b.width * b.height > a.width * a.height ? b : a))
+    width = mode.width
+    height = mode.height
+  }
+
+  // Highest advertised fps <= requested (small tolerance), else the lowest.
+  let fps = opts.fps
+  if (mode && mode.fps.length) {
+    const candidates = [...mode.fps].sort((a, b) => a - b)
+    const atMost = candidates.filter((f) => f <= opts.fps + 0.5)
+    fps = atMost.length ? atMost[atMost.length - 1] : candidates[0]
+  }
+
+  return { device, width, height, fps }
+}
+
+export class CaptureSession {
+  private proc: ChildProcessWithoutNullStreams | null = null
+  private stopping = false
+
+  /**
+   * Spawn the helper and resolve with the ACTUAL frame dimensions (from its
+   * META line) once the first frame is captured. Frames then flow to `port`.
+   */
+  start(
+    port: MessagePortMain,
+    opts: ResolvedCapture,
+    onError: (msg: string) => void
+  ): Promise<{ width: number; height: number }> {
+    this.stopping = false
+
+    const args = [
+      'stream',
+      '--device',
+      opts.device,
+      '--width',
+      String(opts.width),
+      '--height',
+      String(opts.height),
+      '--fps',
+      String(opts.fps)
+    ]
+    console.log('[capture] spawn helper', args.join(' '))
+    const proc = spawn(helperPath(), args)
+    this.proc = proc
+
+    return new Promise((resolve, reject) => {
+      let stderr = ''
+      let seq = 0
+      let started = false
+
+      const startupTimeout = setTimeout(() => {
+        if (!started) {
+          this.stop()
+          reject(new Error('capture start timed out'))
+        }
+      }, 10000)
+
+      const attachPump = (width: number, height: number): void => {
+        const frameBytes = width * height * 2 // yuvs
+        const frameBuf = Buffer.allocUnsafe(frameBytes)
+        let filled = 0
+
+        // Ack-based backpressure: only one frame in flight; while the renderer
+        // is busy the freshest frame waits in pendingBuf (older ones drop).
+        // Flooding the port faster than the renderer draws backs up the message
+        // queue and starves its event loop (input goes dead).
+        let rendererReady = true
+        let hasPending = false
+        const pendingBuf = Buffer.allocUnsafe(frameBytes)
+
+        const post = (buf: Buffer): void => {
+          const ab = new ArrayBuffer(frameBytes)
+          new Uint8Array(ab).set(buf)
+          rendererReady = false
+          try {
+            port.postMessage({ seq: seq++, emitAbs: nowAbs(), width, height, buf: ab })
+          } catch {
+            this.stop()
+          }
+        }
+
+        port.on('message', () => {
+          if (hasPending) {
+            hasPending = false
+            post(pendingBuf)
+          } else {
+            rendererReady = true
+          }
+        })
+
+        proc.stdout.on('data', (chunk: Buffer) => {
+          let off = 0
+          while (off < chunk.length) {
+            const take = Math.min(frameBytes - filled, chunk.length - off)
+            chunk.copy(frameBuf, filled, off, off + take)
+            filled += take
+            off += take
+            if (filled < frameBytes) break
+
+            filled = 0
+            if (rendererReady) {
+              post(frameBuf)
+            } else {
+              frameBuf.copy(pendingBuf)
+              hasPending = true
+            }
+          }
+        })
+      }
+
+      proc.stderr.on('data', (d: Buffer) => {
+        const text = d.toString()
+        const meta = text.match(/^META\s+(\{.*\})/m)
+        if (meta && !started) {
+          started = true
+          clearTimeout(startupTimeout)
+          try {
+            const { width, height } = JSON.parse(meta[1])
+            console.log('[capture] actual mode', width, 'x', height)
+            attachPump(width, height)
+            resolve({ width, height })
+          } catch (e) {
+            this.stop()
+            reject(e)
+          }
+          return
+        }
+        stderr += text
+        console.error('[capture][helper]', text.trim())
+      })
+
+      proc.on('close', (code) => {
+        console.log('[capture] helper closed code=', code, 'frames=', seq)
+        const wasCurrent = this.proc === proc
+        if (wasCurrent) this.proc = null
+        clearTimeout(startupTimeout)
+        // Any unexpected end (device unplugged, signal loss) => notify the
+        // renderer so it doesn't keep showing a frozen frame.
+        if (wasCurrent && !this.stopping) {
+          const msg = stderr.trim() || 'capture ended (device disconnected?)'
+          if (started) onError(msg)
+          else reject(new Error(msg))
+        }
+      })
+      proc.on('error', (e) => {
+        clearTimeout(startupTimeout)
+        if (started) onError(e.message)
+        else reject(e)
+      })
+    })
+  }
+
+  stop(): void {
+    this.stopping = true
+    if (this.proc) {
+      const proc = this.proc
+      this.proc = null
+      // SIGINT lets the helper tear down the AVFoundation session cleanly —
+      // hard kills can wedge the capture device / camera daemon.
+      try {
+        proc.kill('SIGINT')
+      } catch {
+        /* already gone */
+      }
+      setTimeout(() => {
+        try {
+          proc.kill('SIGKILL')
+        } catch {
+          /* already gone */
+        }
+      }, 1500)
+    }
+  }
+
+  get running(): boolean {
+    return this.proc !== null
+  }
+}

--- a/desktop/src/main/capture/engine.ts
+++ b/desktop/src/main/capture/engine.ts
@@ -1,13 +1,13 @@
-// Uncompressed (YUY2/yuvs) capture — macOS Phase 1. Spawns the bundled
-// nanokvm-capture Swift helper (native AVFoundation; ffmpeg's avfoundation
-// input freezes on >=1080p uncompressed frames), assembles exact-size raw
-// frames (O(n) fill buffer — a naive Buffer.concat is O(n^2) and throttles the
-// pipeline), and pushes each frame to the renderer over a MessagePortMain.
-import { ChildProcessWithoutNullStreams, execFile, spawn } from 'child_process'
-import { existsSync } from 'fs'
-import { join } from 'path'
+// Uncompressed (YUY2/yuyv422) capture engine. A platform backend (see
+// backends.ts) enumerates devices and provides a capture process that writes
+// raw frames to stdout; this module assembles exact-size frames (O(n) fill
+// buffer — a naive Buffer.concat is O(n^2) and throttles the pipeline) and
+// pushes each one to the renderer over a MessagePortMain.
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
 import { performance } from 'perf_hooks'
 import type { MessagePortMain } from 'electron'
+
+import { pickBackend } from './backends'
 
 export type CaptureDevice = { index: number; name: string }
 export type CaptureOptions = {
@@ -19,85 +19,69 @@ export type CaptureOptions = {
   requestId?: number
 }
 export type Mode = { width: number; height: number; fps: number[] }
-// device is the AVFoundation device NAME: indices are not stable — Continuity
-// cameras (iPhone/Desk View) insert and remove themselves and shift the list.
+// device is the backend-specific id: AVFoundation/DirectShow device NAME
+// (indices are not stable — e.g. Continuity cameras shift the macOS list),
+// or the /dev/videoN path on Linux.
 export type ResolvedCapture = { device: string; width: number; height: number; fps: number }
-
-const HELPER_CANDIDATES = [
-  process.env.NANOKVM_CAPTURE_PATH,
-  // packaged: resources/ is asarUnpacked (binaries can't execute from asar)
-  join(__dirname, '../../resources/nanokvm-capture').replace('app.asar', 'app.asar.unpacked')
-].filter(Boolean) as string[]
-
-function helperPath(): string {
-  const p = HELPER_CANDIDATES.find((c) => existsSync(c))
-  if (!p) throw new Error('nanokvm-capture helper not found (build it with pnpm build:capture)')
-  return p
+export type StreamSpec = {
+  command: string
+  args: string[]
+  // true: the process reports actually-delivered dimensions via a stderr
+  // "META {json}" line before frames flow (the capture stack may serve the
+  // signal-native mode regardless of the request). false: frames are exactly
+  // the requested size, and the first stdout data signals a healthy start.
+  awaitMeta: boolean
 }
+export type Backend = {
+  listDevices(): Promise<{ id: string; name: string }[]>
+  listModes(id: string): Promise<Mode[]>
+  streamSpec(resolved: ResolvedCapture): StreamSpec
+}
+
+const backend = pickBackend()
 
 const nowAbs = (): number => performance.timeOrigin + performance.now()
 
-type HelperFormat = { pixfmt: string; width: number; height: number; fps: number[] }
-type HelperDevice = { name: string; formats: HelperFormat[] }
-
-function listAll(): Promise<HelperDevice[]> {
-  return new Promise((resolve) => {
-    execFile(helperPath(), ['list'], (_err, stdout) => {
-      try {
-        resolve(JSON.parse(stdout).devices as HelperDevice[])
-      } catch {
-        resolve([])
-      }
-    })
-  })
-}
-
 /** Enumerate video capture devices. */
 export async function listDevices(): Promise<CaptureDevice[]> {
-  return (await listAll()).map((d, index) => ({ index, name: d.name }))
+  return (await backend.listDevices()).map((d, index) => ({ index, name: d.name }))
 }
 
 /** Pick the most likely capture device when the caller doesn't specify one. */
-function autoPick(devices: HelperDevice[]): string {
-  const pref = devices.find(
-    (d) =>
-      /usb|video|capture|hdmi|kvm/i.test(d.name) &&
-      !/facetime|desk view|iphone|capture screen/i.test(d.name)
+function autoPick<T extends { name: string }>(devices: T[]): T | undefined {
+  return (
+    devices.find(
+      (d) =>
+        /usb|video|capture|hdmi|kvm/i.test(d.name) &&
+        !/facetime|desk view|iphone|capture screen/i.test(d.name)
+    ) || devices[0]
   )
-  return (pref || devices[0])?.name ?? ''
 }
 
 /**
  * Resolve a requested capture to a device + a mode the device advertises.
  * If the requested resolution isn't offered, fall back to the largest one.
- * Note the UVC stack may still serve the signal-native mode regardless — the
- * helper reports the ACTUAL dimensions when the stream starts.
  */
 export async function resolveCapture(opts: CaptureOptions): Promise<ResolvedCapture> {
-  const devices = await listAll()
+  const devices = await backend.listDevices()
   const byName = opts.deviceName ? devices.find((d) => d.name === opts.deviceName) : undefined
   const byIndex = opts.deviceIndex !== undefined ? devices[opts.deviceIndex] : undefined
-  const device = byName?.name || byIndex?.name || autoPick(devices)
+  const device = byName || byIndex || autoPick(devices)
   if (!device) throw new Error('no capture device found')
 
-  const modes = new Map<string, Mode>()
-  for (const f of devices.find((d) => d.name === device)?.formats ?? []) {
-    if (f.pixfmt !== 'yuvs') continue
-    const key = `${f.width}x${f.height}`
-    const mode = modes.get(key) || { width: f.width, height: f.height, fps: [] }
-    for (const v of f.fps) if (v && !mode.fps.includes(v)) mode.fps.push(v)
-    modes.set(key, mode)
-  }
+  const modes = await backend.listModes(device.id)
 
   let { width, height } = opts
-  let mode = modes.get(`${width}x${height}`)
-  if (!mode && modes.size) {
-    mode = [...modes.values()].reduce((a, b) => (b.width * b.height > a.width * a.height ? b : a))
+  let mode = modes.find((m) => m.width === width && m.height === height)
+  if (!mode && modes.length) {
+    mode = modes.reduce((a, b) => (b.width * b.height > a.width * a.height ? b : a))
     width = mode.width
     height = mode.height
   }
 
   // Highest advertised fps <= requested (small tolerance), else the lowest.
+  // Backends that don't report per-mode rates (v4l2) leave fps empty and the
+  // driver clamps the requested rate itself.
   let fps = opts.fps
   if (mode && mode.fps.length) {
     const candidates = [...mode.fps].sort((a, b) => a - b)
@@ -105,7 +89,7 @@ export async function resolveCapture(opts: CaptureOptions): Promise<ResolvedCapt
     fps = atMost.length ? atMost[atMost.length - 1] : candidates[0]
   }
 
-  return { device, width, height, fps }
+  return { device: device.id, width, height, fps }
 }
 
 export class CaptureSession {
@@ -113,8 +97,9 @@ export class CaptureSession {
   private stopping = false
 
   /**
-   * Spawn the helper and resolve with the ACTUAL frame dimensions (from its
-   * META line) once the first frame is captured. Frames then flow to `port`.
+   * Spawn the capture process and resolve with the frame dimensions once the
+   * stream is up (META line, or first data for exact-size backends). Frames
+   * then flow to `port`.
    */
   start(
     port: MessagePortMain,
@@ -123,18 +108,8 @@ export class CaptureSession {
   ): Promise<{ width: number; height: number }> {
     this.stopping = false
 
-    const args = [
-      'stream',
-      '--device',
-      opts.device,
-      '--width',
-      String(opts.width),
-      '--height',
-      String(opts.height),
-      '--fps',
-      String(opts.fps)
-    ]
-    const proc = spawn(helperPath(), args)
+    const spec = backend.streamSpec(opts)
+    const proc = spawn(spec.command, spec.args)
     this.proc = proc
 
     return new Promise((resolve, reject) => {
@@ -149,8 +124,15 @@ export class CaptureSession {
         }
       }, 10000)
 
+      const begin = (width: number, height: number): void => {
+        started = true
+        clearTimeout(startupTimeout)
+        attachPump(width, height)
+        resolve({ width, height })
+      }
+
       const attachPump = (width: number, height: number): void => {
-        const frameBytes = width * height * 2 // yuvs
+        const frameBytes = width * height * 2 // yuyv422
         const frameBuf = Buffer.allocUnsafe(frameBytes)
         let filled = 0
 
@@ -202,24 +184,31 @@ export class CaptureSession {
         })
       }
 
-      proc.stderr.on('data', (d: Buffer) => {
-        const text = d.toString()
-        const meta = text.match(/^META\s+(\{.*\})/m)
-        if (meta && !started) {
-          started = true
-          clearTimeout(startupTimeout)
-          try {
-            const { width, height } = JSON.parse(meta[1])
-            attachPump(width, height)
-            resolve({ width, height })
-          } catch (e) {
-            this.stop()
-            reject(e)
+      if (spec.awaitMeta) {
+        proc.stderr.on('data', (d: Buffer) => {
+          const text = d.toString()
+          const meta = text.match(/^META\s+(\{.*\})/m)
+          if (meta && !started) {
+            try {
+              const { width, height } = JSON.parse(meta[1])
+              begin(width, height)
+            } catch (e) {
+              this.stop()
+              clearTimeout(startupTimeout)
+              reject(e)
+            }
+            return
           }
-          return
-        }
-        stderr += text
-      })
+          stderr += text
+        })
+      } else {
+        proc.stderr.on('data', (d: Buffer) => {
+          stderr += d.toString()
+        })
+        proc.stdout.once('data', () => {
+          if (!started) begin(opts.width, opts.height)
+        })
+      }
 
       proc.on('close', () => {
         const wasCurrent = this.proc === proc
@@ -235,8 +224,15 @@ export class CaptureSession {
       })
       proc.on('error', (e) => {
         clearTimeout(startupTimeout)
-        if (started) onError(e.message)
-        else reject(e)
+        const err = e as NodeJS.ErrnoException
+        const msg =
+          err.code === 'ENOENT'
+            ? spec.awaitMeta
+              ? `capture helper not found: ${spec.command}`
+              : 'FFmpeg not found — install FFmpeg or set FFMPEG_PATH'
+            : e.message
+        if (started) onError(msg)
+        else reject(new Error(msg))
       })
     })
   }
@@ -246,10 +242,15 @@ export class CaptureSession {
     if (this.proc) {
       const proc = this.proc
       this.proc = null
-      // SIGINT lets the helper tear down the AVFoundation session cleanly —
-      // hard kills can wedge the capture device / camera daemon.
+      // Graceful first: SIGINT lets the process tear down the capture session
+      // cleanly (hard kills can wedge the device / camera daemon). On Windows
+      // there are no signals — ffmpeg quits on 'q' via stdin.
       try {
-        proc.kill('SIGINT')
+        if (process.platform === 'win32') {
+          proc.stdin.write('q')
+        } else {
+          proc.kill('SIGINT')
+        }
       } catch {
         /* already gone */
       }

--- a/desktop/src/main/capture/engine.ts
+++ b/desktop/src/main/capture/engine.ts
@@ -11,6 +11,7 @@ import type { MessagePortMain } from 'electron'
 
 export type CaptureDevice = { index: number; name: string }
 export type CaptureOptions = {
+  deviceName?: string
   deviceIndex?: number
   width: number
   height: number
@@ -24,7 +25,8 @@ export type ResolvedCapture = { device: string; width: number; height: number; f
 
 const HELPER_CANDIDATES = [
   process.env.NANOKVM_CAPTURE_PATH,
-  join(__dirname, '../../resources/nanokvm-capture')
+  // packaged: resources/ is asarUnpacked (binaries can't execute from asar)
+  join(__dirname, '../../resources/nanokvm-capture').replace('app.asar', 'app.asar.unpacked')
 ].filter(Boolean) as string[]
 
 function helperPath(): string {
@@ -73,8 +75,9 @@ function autoPick(devices: HelperDevice[]): string {
  */
 export async function resolveCapture(opts: CaptureOptions): Promise<ResolvedCapture> {
   const devices = await listAll()
+  const byName = opts.deviceName ? devices.find((d) => d.name === opts.deviceName) : undefined
   const byIndex = opts.deviceIndex !== undefined ? devices[opts.deviceIndex] : undefined
-  const device = byIndex ? byIndex.name : autoPick(devices)
+  const device = byName?.name || byIndex?.name || autoPick(devices)
   if (!device) throw new Error('no capture device found')
 
   const modes = new Map<string, Mode>()
@@ -131,7 +134,6 @@ export class CaptureSession {
       '--fps',
       String(opts.fps)
     ]
-    console.log('[capture] spawn helper', args.join(' '))
     const proc = spawn(helperPath(), args)
     this.proc = proc
 
@@ -208,7 +210,6 @@ export class CaptureSession {
           clearTimeout(startupTimeout)
           try {
             const { width, height } = JSON.parse(meta[1])
-            console.log('[capture] actual mode', width, 'x', height)
             attachPump(width, height)
             resolve({ width, height })
           } catch (e) {
@@ -218,11 +219,9 @@ export class CaptureSession {
           return
         }
         stderr += text
-        console.error('[capture][helper]', text.trim())
       })
 
-      proc.on('close', (code) => {
-        console.log('[capture] helper closed code=', code, 'frames=', seq)
+      proc.on('close', () => {
         const wasCurrent = this.proc === proc
         if (wasCurrent) this.proc = null
         clearTimeout(startupTimeout)

--- a/desktop/src/main/events/capture.ts
+++ b/desktop/src/main/events/capture.ts
@@ -1,0 +1,53 @@
+import { ipcMain, IpcMainInvokeEvent, MessageChannelMain } from 'electron'
+
+import { IpcEvents } from '../../common/ipc-events'
+import {
+  CaptureDevice,
+  CaptureOptions,
+  CaptureSession,
+  listDevices,
+  resolveCapture
+} from '../capture/engine'
+
+const session = new CaptureSession()
+
+export function registerCapture(): void {
+  ipcMain.handle(IpcEvents.GET_CAPTURE_DEVICES, getCaptureDevices)
+  ipcMain.handle(IpcEvents.START_CAPTURE, startCapture)
+  ipcMain.handle(IpcEvents.STOP_CAPTURE, stopCapture)
+}
+
+async function getCaptureDevices(): Promise<CaptureDevice[]> {
+  return listDevices()
+}
+
+async function startCapture(e: IpcMainInvokeEvent, opts: CaptureOptions): Promise<boolean> {
+  session.stop()
+
+  // Resolve to a device (by name) + an advertised mode; the helper reports the
+  // ACTUAL delivered dimensions once the stream starts (the UVC stack may serve
+  // the signal-native mode regardless of the request).
+  const resolved = await resolveCapture(opts)
+  console.log('[capture] requested', opts, '-> resolved', resolved)
+
+  const { port1, port2 } = new MessageChannelMain()
+  port1.start()
+
+  const actual = await session.start(port1, resolved, (msg) => {
+    if (!e.sender.isDestroyed()) e.sender.send(IpcEvents.CAPTURE_ERROR, msg)
+  })
+
+  // Hand the renderer end of the channel to the page (preload forwards it on).
+  // requestId lets the renderer ignore ports from superseded start requests.
+  e.sender.postMessage(
+    IpcEvents.CAPTURE_PORT,
+    { width: actual.width, height: actual.height, requestId: opts.requestId },
+    [port2]
+  )
+  return true
+}
+
+async function stopCapture(): Promise<boolean> {
+  session.stop()
+  return true
+}

--- a/desktop/src/main/events/capture.ts
+++ b/desktop/src/main/events/capture.ts
@@ -28,7 +28,6 @@ async function startCapture(e: IpcMainInvokeEvent, opts: CaptureOptions): Promis
   // ACTUAL delivered dimensions once the stream starts (the UVC stack may serve
   // the signal-native mode regardless of the request).
   const resolved = await resolveCapture(opts)
-  console.log('[capture] requested', opts, '-> resolved', resolved)
 
   const { port1, port2 } = new MessageChannelMain()
   port1.start()

--- a/desktop/src/main/events/index.ts
+++ b/desktop/src/main/events/index.ts
@@ -1,3 +1,4 @@
 export * from './app'
+export * from './capture'
 export * from './serial-port'
 export * from './updater'

--- a/desktop/src/main/events/serial-port.ts
+++ b/desktop/src/main/events/serial-port.ts
@@ -64,7 +64,6 @@ async function closeSerialPort(): Promise<boolean> {
 }
 
 async function sendKeyboard(_: IpcMainInvokeEvent, report: number[]): Promise<void> {
-  console.log('[input] SEND_KEYBOARD')
   try {
     await device.sendKeyboardData(report)
   } catch (error) {
@@ -72,9 +71,7 @@ async function sendKeyboard(_: IpcMainInvokeEvent, report: number[]): Promise<vo
   }
 }
 
-let mouseLog = 0
 async function sendMouse(_: IpcMainInvokeEvent, report: number[]): Promise<void> {
-  if (mouseLog++ % 30 === 0) console.log('[input] SEND_MOUSE x30')
   try {
     await device.sendMouseData(report)
   } catch (error) {

--- a/desktop/src/main/events/serial-port.ts
+++ b/desktop/src/main/events/serial-port.ts
@@ -64,6 +64,7 @@ async function closeSerialPort(): Promise<boolean> {
 }
 
 async function sendKeyboard(_: IpcMainInvokeEvent, report: number[]): Promise<void> {
+  console.log('[input] SEND_KEYBOARD')
   try {
     await device.sendKeyboardData(report)
   } catch (error) {
@@ -71,7 +72,9 @@ async function sendKeyboard(_: IpcMainInvokeEvent, report: number[]): Promise<vo
   }
 }
 
+let mouseLog = 0
 async function sendMouse(_: IpcMainInvokeEvent, report: number[]): Promise<void> {
+  if (mouseLog++ % 30 === 0) console.log('[input] SEND_MOUSE x30')
   try {
     await device.sendMouseData(report)
   } catch (error) {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -31,11 +31,6 @@ function createWindow(): void {
     mainWindow.show()
   })
 
-  // TEMP (Phase 1 debug): surface renderer console in the terminal
-  mainWindow.webContents.on('console-message', (_e, _lvl, message) => {
-    if (/capture|webgl|port|gl error/i.test(message)) console.log('[renderer]', message)
-  })
-
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -19,13 +19,21 @@ function createWindow(): void {
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false
+      sandbox: false,
+      // Keep the capture canvas (rAF-driven) updating when the window is not
+      // focused — a KVM is often in the background while you use the target.
+      backgroundThrottling: false
     }
   })
 
   mainWindow.on('ready-to-show', () => {
     mainWindow.maximize()
     mainWindow.show()
+  })
+
+  // TEMP (Phase 1 debug): surface renderer console in the terminal
+  mainWindow.webContents.on('console-message', (_e, _lvl, message) => {
+    if (/capture|webgl|port|gl error/i.test(message)) console.log('[renderer]', message)
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
@@ -54,6 +62,7 @@ app.whenReady().then(() => {
 
   events.registerApp()
   events.registerSerialPort()
+  events.registerCapture()
 
   createWindow()
 

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,5 +1,13 @@
 import { electronAPI } from '@electron-toolkit/preload'
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
+
+import { IpcEvents } from '../common/ipc-events'
+
+// MessagePorts cannot cross the contextBridge, so forward the capture channel's
+// port directly into the page via window.postMessage (with transfer).
+ipcRenderer.on(IpcEvents.CAPTURE_PORT, (e, meta) => {
+  window.postMessage({ type: 'capture-port', meta }, '*', e.ports)
+})
 
 // Custom APIs for renderer
 const api = {}

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -46,6 +46,7 @@ const App = (): ReactElement => {
   const [resolution, setResolution] = useAtom(resolutionAtom)
 
   const [state, setState] = useState<State>('loading')
+  const [captureNonce, setCaptureNonce] = useState(0)
   const prevCaptureMode = useRef(false)
 
   useEffect(() => {
@@ -86,7 +87,14 @@ const App = (): ReactElement => {
           fps: fpsFor(resolution.width, resolution.height),
           deviceName: captureDevice || undefined,
           sharpness,
-          onError: (msg) => failCapture(msg)
+          onError: (msg) => {
+            if (/video mode changed/i.test(msg)) {
+              // HDMI source resolution changed — restart at the new mode
+              setTimeout(() => setCaptureNonce((n) => n + 1), 500)
+            } else {
+              failCapture(msg)
+            }
+          }
         })
         .then(() => setVideoState('connected'))
         .catch((err) => failCapture(err instanceof Error ? err.message : String(err)))
@@ -98,7 +106,7 @@ const App = (): ReactElement => {
     // <video> element has no stream otherwise).
     if (wasCapture) reopenCamera()
     return
-  }, [captureMode, state, resolution, captureDevice])
+  }, [captureMode, state, resolution, captureDevice, captureNonce])
 
   // Uncompressed frames are structured-clone copied across processes; past
   // ~150 MB/s the copies crowd out input IPC on both event loops (1080p60 is

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -12,15 +12,17 @@ import { Menu } from '@renderer/components/menu'
 import { Mouse } from '@renderer/components/mouse'
 import { VirtualKeyboard } from '@renderer/components/virtual-keyboard'
 import {
+  captureDeviceAtom,
   captureModeAtom,
   resolutionAtom,
   serialPortStateAtom,
+  sharpnessAtom,
   videoScaleAtom,
   videoStateAtom
 } from '@renderer/jotai/device'
 import { isKeyboardEnableAtom } from '@renderer/jotai/keyboard'
 import { mouseModeAtom, mouseStyleAtom } from '@renderer/jotai/mouse'
-import { ffmpegCamera } from '@renderer/libs/capture/ffmpeg-camera'
+import { captureCamera } from '@renderer/libs/capture/capture-camera'
 import { camera } from '@renderer/libs/media/camera'
 import { requestCameraPermission } from '@renderer/libs/media/permission'
 import * as storage from '@renderer/libs/storage'
@@ -35,6 +37,8 @@ const App = (): ReactElement => {
   const videoScale = useAtomValue(videoScaleAtom)
   const [videoState, setVideoState] = useAtom(videoStateAtom)
   const [captureMode, setCaptureMode] = useAtom(captureModeAtom)
+  const [captureDevice, setCaptureDevice] = useAtom(captureDeviceAtom)
+  const [sharpness, setSharpness] = useAtom(sharpnessAtom)
   const serialPortState = useAtomValue(serialPortStateAtom)
   const mouseMode = useAtomValue(mouseModeAtom)
   const mouseStyle = useAtomValue(mouseStyleAtom)
@@ -51,27 +55,18 @@ const App = (): ReactElement => {
     }
 
     setCaptureMode(storage.getCaptureMode())
+    setCaptureDevice(storage.getCaptureDevice())
+    setSharpness(storage.getSharpness())
     requestMediaPermissions(resolution)
 
     return (): void => {
       camera.close()
-      ffmpegCamera.close()
+      captureCamera.close()
       window.electron.ipcRenderer.invoke(IpcEvents.CLOSE_SERIAL_PORT)
     }
   }, [])
 
-  useEffect(() => {
-    console.log(
-      'capture-debug STATE captureMode=',
-      captureMode,
-      'videoState=',
-      videoState,
-      'serialPortState=',
-      serialPortState
-    )
-  }, [captureMode, videoState, serialPortState])
-
-  // Drive the FFmpeg uncompressed-capture path when capture mode is on.
+  // Drive the uncompressed-capture path when capture mode is on.
   // Depends on `resolution` so a resolution change cleanly restarts the session.
   useEffect(() => {
     if (state !== 'success') return
@@ -83,25 +78,27 @@ const App = (): ReactElement => {
       camera.close()
       const canvas = document.getElementById('video') as HTMLCanvasElement | null
       if (!canvas) return
-      ffmpegCamera
+      captureCamera
         .open({
           canvas,
           width: resolution.width,
           height: resolution.height,
           fps: fpsFor(resolution.width, resolution.height),
+          deviceName: captureDevice || undefined,
+          sharpness,
           onError: (msg) => failCapture(msg)
         })
         .then(() => setVideoState('connected'))
         .catch((err) => failCapture(err instanceof Error ? err.message : String(err)))
-      return (): void => ffmpegCamera.close()
+      return (): void => captureCamera.close()
     }
 
-    ffmpegCamera.close()
+    captureCamera.close()
     // Ticked -> unticked: restore the regular getUserMedia camera (the swapped-in
     // <video> element has no stream otherwise).
     if (wasCapture) reopenCamera()
     return
-  }, [captureMode, state, resolution])
+  }, [captureMode, state, resolution, captureDevice])
 
   // Uncompressed frames are structured-clone copied across processes; past
   // ~150 MB/s the copies crowd out input IPC on both event loops (1080p60 is
@@ -116,7 +113,7 @@ const App = (): ReactElement => {
   // regular camera path; serial (keyboard/mouse) is unaffected.
   function failCapture(msg: string): void {
     console.error('capture error:', msg)
-    message.error(`Uncompressed capture failed: ${msg.slice(0, 300)}`, 8)
+    message.error(`${t('video.captureFailed')}: ${msg.slice(0, 300)}`, 8)
     setCaptureMode(false)
     storage.setCaptureMode(false)
   }

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -1,7 +1,7 @@
-import { ReactElement, useEffect, useState } from 'react'
-import { Result, Spin } from 'antd'
+import { ReactElement, useEffect, useRef, useState } from 'react'
+import { message, Result, Spin } from 'antd'
 import clsx from 'clsx'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { useTranslation } from 'react-i18next'
 import { useMediaQuery } from 'react-responsive'
 
@@ -12,6 +12,7 @@ import { Menu } from '@renderer/components/menu'
 import { Mouse } from '@renderer/components/mouse'
 import { VirtualKeyboard } from '@renderer/components/virtual-keyboard'
 import {
+  captureModeAtom,
   resolutionAtom,
   serialPortStateAtom,
   videoScaleAtom,
@@ -19,9 +20,10 @@ import {
 } from '@renderer/jotai/device'
 import { isKeyboardEnableAtom } from '@renderer/jotai/keyboard'
 import { mouseModeAtom, mouseStyleAtom } from '@renderer/jotai/mouse'
+import { ffmpegCamera } from '@renderer/libs/capture/ffmpeg-camera'
 import { camera } from '@renderer/libs/media/camera'
 import { requestCameraPermission } from '@renderer/libs/media/permission'
-import { getVideoResolution } from '@renderer/libs/storage'
+import * as storage from '@renderer/libs/storage'
 import type { Resolution } from '@renderer/types'
 
 type State = 'loading' | 'success' | 'failed'
@@ -31,28 +33,108 @@ const App = (): ReactElement => {
   const isBigScreen = useMediaQuery({ minWidth: 850 })
 
   const videoScale = useAtomValue(videoScaleAtom)
-  const videoState = useAtomValue(videoStateAtom)
+  const [videoState, setVideoState] = useAtom(videoStateAtom)
+  const [captureMode, setCaptureMode] = useAtom(captureModeAtom)
   const serialPortState = useAtomValue(serialPortStateAtom)
   const mouseMode = useAtomValue(mouseModeAtom)
   const mouseStyle = useAtomValue(mouseStyleAtom)
   const isKeyboardEnable = useAtomValue(isKeyboardEnableAtom)
-  const setResolution = useSetAtom(resolutionAtom)
+  const [resolution, setResolution] = useAtom(resolutionAtom)
 
   const [state, setState] = useState<State>('loading')
+  const prevCaptureMode = useRef(false)
 
   useEffect(() => {
-    const resolution = getVideoResolution()
+    const resolution = storage.getVideoResolution()
     if (resolution) {
       setResolution(resolution)
     }
 
+    setCaptureMode(storage.getCaptureMode())
     requestMediaPermissions(resolution)
 
     return (): void => {
       camera.close()
+      ffmpegCamera.close()
       window.electron.ipcRenderer.invoke(IpcEvents.CLOSE_SERIAL_PORT)
     }
   }, [])
+
+  useEffect(() => {
+    console.log(
+      'capture-debug STATE captureMode=',
+      captureMode,
+      'videoState=',
+      videoState,
+      'serialPortState=',
+      serialPortState
+    )
+  }, [captureMode, videoState, serialPortState])
+
+  // Drive the FFmpeg uncompressed-capture path when capture mode is on.
+  // Depends on `resolution` so a resolution change cleanly restarts the session.
+  useEffect(() => {
+    if (state !== 'success') return
+
+    const wasCapture = prevCaptureMode.current
+    prevCaptureMode.current = captureMode
+
+    if (captureMode) {
+      camera.close()
+      const canvas = document.getElementById('video') as HTMLCanvasElement | null
+      if (!canvas) return
+      ffmpegCamera
+        .open({
+          canvas,
+          width: resolution.width,
+          height: resolution.height,
+          fps: fpsFor(resolution.width, resolution.height),
+          onError: (msg) => failCapture(msg)
+        })
+        .then(() => setVideoState('connected'))
+        .catch((err) => failCapture(err instanceof Error ? err.message : String(err)))
+      return (): void => ffmpegCamera.close()
+    }
+
+    ffmpegCamera.close()
+    // Ticked -> unticked: restore the regular getUserMedia camera (the swapped-in
+    // <video> element has no stream otherwise).
+    if (wasCapture) reopenCamera()
+    return
+  }, [captureMode, state, resolution])
+
+  // Uncompressed frames are structured-clone copied across processes; past
+  // ~150 MB/s the copies crowd out input IPC on both event loops (1080p60 is
+  // ~250 MB/s and keyboard/mouse go unresponsive). Highest fps within budget:
+  // 720p -> 60, 1080p -> 30. The device only offers 10/20/30/50/60.
+  function fpsFor(width: number, height: number): number {
+    const budget = 150e6
+    return [60, 50, 30, 20, 10].find((fps) => width * height * 2 * fps <= budget) || 10
+  }
+
+  // A capture failure must not kill the UI — report it and fall back to the
+  // regular camera path; serial (keyboard/mouse) is unaffected.
+  function failCapture(msg: string): void {
+    console.error('capture error:', msg)
+    message.error(`Uncompressed capture failed: ${msg.slice(0, 300)}`, 8)
+    setCaptureMode(false)
+    storage.setCaptureMode(false)
+  }
+
+  async function reopenCamera(): Promise<void> {
+    const videoId = storage.getVideoDevice()
+    if (!videoId) return
+    try {
+      await camera.open(videoId, resolution.width, resolution.height, camera.audioId || undefined)
+      const video = document.getElementById('video') as HTMLVideoElement | null
+      if (!video) return
+      video.srcObject = camera.getStream()
+      setVideoState('connected')
+    } catch (err) {
+      console.error('camera reopen failed:', err)
+      setVideoState('disconnected')
+    }
+  }
 
   async function requestMediaPermissions(resolution?: Resolution): Promise<void> {
     try {
@@ -92,22 +174,36 @@ const App = (): ReactElement => {
       {videoState === 'connected' && serialPortState === 'connected' && (
         <>
           <Menu />
-          <Mouse />
-          {isKeyboardEnable && <Keyboard />}
+          {/* Remount on capture toggle so listeners re-bind to the swapped
+              <video>/<canvas> element (same id, different DOM node). */}
+          <Mouse key={captureMode ? 'mouse-canvas' : 'mouse-video'} />
+          {isKeyboardEnable && <Keyboard key={captureMode ? 'kbd-canvas' : 'kbd-video'} />}
         </>
       )}
 
-      <video
-        id="video"
-        className={clsx(
-          'block max-h-full min-h-[480px] max-w-full min-w-[640px] origin-center object-scale-down select-none',
-          videoState === 'connected' ? 'opacity-100' : 'opacity-0',
-          mouseMode === 'relative' ? 'cursor-none' : mouseStyle
-        )}
-        style={{ transform: `scale(${videoScale})` }}
-        autoPlay
-        playsInline
-      />
+      {captureMode ? (
+        <canvas
+          id="video"
+          className={clsx(
+            'block max-h-full min-h-[480px] max-w-full min-w-[640px] origin-center object-scale-down select-none',
+            videoState === 'connected' ? 'opacity-100' : 'opacity-0',
+            mouseMode === 'relative' ? 'cursor-none' : mouseStyle
+          )}
+          style={{ transform: `scale(${videoScale})` }}
+        />
+      ) : (
+        <video
+          id="video"
+          className={clsx(
+            'block max-h-full min-h-[480px] max-w-full min-w-[640px] origin-center object-scale-down select-none',
+            videoState === 'connected' ? 'opacity-100' : 'opacity-0',
+            mouseMode === 'relative' ? 'cursor-none' : mouseStyle
+          )}
+          style={{ transform: `scale(${videoScale})` }}
+          autoPlay
+          playsInline
+        />
+      )}
 
       <VirtualKeyboard isBigScreen={isBigScreen} />
     </>

--- a/desktop/src/renderer/src/components/device/video.tsx
+++ b/desktop/src/renderer/src/components/device/video.tsx
@@ -53,6 +53,9 @@ export const Video = ({ setMsg }: VideoProps): ReactElement => {
       setDevices(mediaDevices)
 
       if (autoOpen) {
+        // Capture mode owns the device via ffmpeg (App.tsx) — don't also open
+        // it through getUserMedia at startup.
+        if (storage.getCaptureMode()) return
         const videoId = storage.getVideoDevice()
         if (!videoId) return
         const device = mediaDevices.find((d) => d.videoId === videoId)

--- a/desktop/src/renderer/src/components/menu/video/capture-device.tsx
+++ b/desktop/src/renderer/src/components/menu/video/capture-device.tsx
@@ -1,0 +1,65 @@
+import { ReactElement, useState } from 'react'
+import { Popover } from 'antd'
+import clsx from 'clsx'
+import { useAtom, useAtomValue } from 'jotai'
+import { VideoIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { IpcEvents } from '@common/ipc-events'
+import { captureDeviceAtom, captureModeAtom } from '@renderer/jotai/device'
+import * as storage from '@renderer/libs/storage'
+
+type CaptureDeviceInfo = {
+  index: number
+  name: string
+}
+
+// Capture-device picker for the uncompressed mode. AVFoundation devices are
+// selected by NAME (indices shift when Continuity cameras come and go).
+export const CaptureDevice = (): ReactElement | null => {
+  const { t } = useTranslation()
+  const captureMode = useAtomValue(captureModeAtom)
+  const [captureDevice, setCaptureDevice] = useAtom(captureDeviceAtom)
+  const [devices, setDevices] = useState<CaptureDeviceInfo[]>([])
+
+  if (!captureMode) return null
+
+  async function getDevices(): Promise<void> {
+    const list = await window.electron.ipcRenderer.invoke(IpcEvents.GET_CAPTURE_DEVICES)
+    setDevices(list)
+  }
+
+  function selectDevice(name: string): void {
+    setCaptureDevice(name)
+    storage.setCaptureDevice(name)
+  }
+
+  const content = (
+    <>
+      {devices.map((device) => (
+        <div
+          key={device.name}
+          className={clsx(
+            'flex cursor-pointer items-center space-x-1.5 rounded px-3 py-1.5 select-none hover:bg-neutral-700/60',
+            captureDevice === device.name ? 'text-blue-500' : 'text-white'
+          )}
+          onClick={() => selectDevice(device.name)}
+        >
+          <span>{device.name}</span>
+        </div>
+      ))}
+    </>
+  )
+
+  return (
+    <Popover content={content} placement="rightTop" arrow={false} align={{ offset: [13, 0] }}>
+      <div
+        className="flex h-[30px] cursor-pointer items-center space-x-2 rounded px-3 text-neutral-300 hover:bg-neutral-700/50"
+        onMouseEnter={getDevices}
+      >
+        <VideoIcon size={16} />
+        <span className="text-sm select-none">{t('video.captureDevice')}</span>
+      </div>
+    </Popover>
+  )
+}

--- a/desktop/src/renderer/src/components/menu/video/capture.tsx
+++ b/desktop/src/renderer/src/components/menu/video/capture.tsx
@@ -2,13 +2,14 @@ import { ReactElement, useEffect } from 'react'
 import clsx from 'clsx'
 import { useAtom } from 'jotai'
 import { CheckIcon, ZapIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 
 import { captureModeAtom } from '@renderer/jotai/device'
 import * as storage from '@renderer/libs/storage'
 
-// Phase 1 (experimental, macOS): toggle uncompressed FFmpeg capture. English-only
-// label for now — i18n across all locales is Phase 2.
+// Experimental (macOS): toggle uncompressed native capture.
 export const Capture = (): ReactElement => {
+  const { t } = useTranslation()
   const [captureMode, setCaptureMode] = useAtom(captureModeAtom)
 
   useEffect(() => {
@@ -31,7 +32,7 @@ export const Capture = (): ReactElement => {
     >
       <div className="flex items-center space-x-2">
         <ZapIcon size={16} />
-        <span className="text-sm select-none">Uncompressed (exp.)</span>
+        <span className="text-sm select-none">{t('video.capture')}</span>
       </div>
       {captureMode && <CheckIcon size={14} />}
     </div>

--- a/desktop/src/renderer/src/components/menu/video/capture.tsx
+++ b/desktop/src/renderer/src/components/menu/video/capture.tsx
@@ -1,0 +1,39 @@
+import { ReactElement, useEffect } from 'react'
+import clsx from 'clsx'
+import { useAtom } from 'jotai'
+import { CheckIcon, ZapIcon } from 'lucide-react'
+
+import { captureModeAtom } from '@renderer/jotai/device'
+import * as storage from '@renderer/libs/storage'
+
+// Phase 1 (experimental, macOS): toggle uncompressed FFmpeg capture. English-only
+// label for now — i18n across all locales is Phase 2.
+export const Capture = (): ReactElement => {
+  const [captureMode, setCaptureMode] = useAtom(captureModeAtom)
+
+  useEffect(() => {
+    setCaptureMode(storage.getCaptureMode())
+  }, [setCaptureMode])
+
+  function toggle(): void {
+    const next = !captureMode
+    setCaptureMode(next)
+    storage.setCaptureMode(next)
+  }
+
+  return (
+    <div
+      className={clsx(
+        'flex h-[30px] cursor-pointer items-center justify-between rounded px-3 hover:bg-neutral-700/50',
+        captureMode ? 'text-blue-500' : 'text-neutral-300'
+      )}
+      onClick={toggle}
+    >
+      <div className="flex items-center space-x-2">
+        <ZapIcon size={16} />
+        <span className="text-sm select-none">Uncompressed (exp.)</span>
+      </div>
+      {captureMode && <CheckIcon size={14} />}
+    </div>
+  )
+}

--- a/desktop/src/renderer/src/components/menu/video/device.tsx
+++ b/desktop/src/renderer/src/components/menu/video/device.tsx
@@ -5,22 +5,28 @@ import { useAtom, useAtomValue } from 'jotai'
 import { VideoIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { resolutionAtom, videoDeviceIdAtom } from '@renderer/jotai/device'
+import { captureModeAtom, resolutionAtom, videoDeviceIdAtom } from '@renderer/jotai/device'
 import { camera } from '@renderer/libs/media/camera'
 import * as storage from '@renderer/libs/storage'
 import type { MediaDevice } from '@renderer/types'
 
-export const Device = (): ReactElement => {
+export const Device = (): ReactElement | null => {
   const { t } = useTranslation()
   const resolution = useAtomValue(resolutionAtom)
+  const captureMode = useAtomValue(captureModeAtom)
   const [videoDeviceId, setVideoDeviceId] = useAtom(videoDeviceIdAtom)
 
   const [devices, setDevices] = useState<MediaDevice[]>([])
   const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
-    getDevices()
-  }, [])
+    // In capture mode the native helper owns the device: don't touch
+    // getUserMedia (even enumerating here opens the camera briefly), and show
+    // only the Capture Device picker.
+    if (!captureMode) getDevices()
+  }, [captureMode])
+
+  if (captureMode) return null
 
   async function getDevices(): Promise<void> {
     try {

--- a/desktop/src/renderer/src/components/menu/video/index.tsx
+++ b/desktop/src/renderer/src/components/menu/video/index.tsx
@@ -2,6 +2,7 @@ import { ReactElement } from 'react'
 import { Popover } from 'antd'
 import { MonitorIcon } from 'lucide-react'
 
+import { Capture } from './capture'
 import { Device } from './device'
 import { Resolution } from './resolution'
 import { Scale } from './scale'
@@ -11,6 +12,7 @@ export const Video = (): ReactElement => {
     <div className="flex flex-col space-y-1">
       <Resolution />
       <Scale />
+      <Capture />
       <Device />
     </div>
   )

--- a/desktop/src/renderer/src/components/menu/video/index.tsx
+++ b/desktop/src/renderer/src/components/menu/video/index.tsx
@@ -3,9 +3,11 @@ import { Popover } from 'antd'
 import { MonitorIcon } from 'lucide-react'
 
 import { Capture } from './capture'
+import { CaptureDevice } from './capture-device'
 import { Device } from './device'
 import { Resolution } from './resolution'
 import { Scale } from './scale'
+import { Sharpness } from './sharpness'
 
 export const Video = (): ReactElement => {
   const content = (
@@ -13,6 +15,8 @@ export const Video = (): ReactElement => {
       <Resolution />
       <Scale />
       <Capture />
+      <CaptureDevice />
+      <Sharpness />
       <Device />
     </div>
   )

--- a/desktop/src/renderer/src/components/menu/video/resolution.tsx
+++ b/desktop/src/renderer/src/components/menu/video/resolution.tsx
@@ -1,11 +1,11 @@
 import React, { ReactElement, useEffect, useState } from 'react'
 import { Button, Divider, InputNumber, Modal, Popover } from 'antd'
 import clsx from 'clsx'
-import { useAtom, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { RatioIcon, Trash2Icon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { resolutionAtom } from '@renderer/jotai/device'
+import { captureModeAtom, resolutionAtom } from '@renderer/jotai/device'
 import { isKeyboardEnableAtom } from '@renderer/jotai/keyboard'
 import { camera } from '@renderer/libs/media/camera'
 import * as storage from '@renderer/libs/storage'
@@ -15,6 +15,7 @@ export const Resolution = (): ReactElement => {
   const { t } = useTranslation()
 
   const [resolution, setResolution] = useAtom(resolutionAtom)
+  const captureMode = useAtomValue(captureModeAtom)
   const setIsKeyboardEnable = useSetAtom(isKeyboardEnableAtom)
 
   const [isOpen, setIsOpen] = useState(false)
@@ -66,16 +67,20 @@ export const Resolution = (): ReactElement => {
   }
 
   async function updateResolution(w: number, h: number): Promise<void> {
-    try {
-      await camera.updateResolution(w, h)
-    } catch (err) {
-      console.log(err)
-      return
-    }
+    // In capture mode the ffmpeg session owns the device; App.tsx restarts it
+    // when the resolution atom changes — don't touch the getUserMedia camera.
+    if (!captureMode) {
+      try {
+        await camera.updateResolution(w, h)
+      } catch (err) {
+        console.log(err)
+        return
+      }
 
-    const video = document.getElementById('video') as HTMLVideoElement
-    if (!video) return
-    video.srcObject = camera.getStream()
+      const video = document.getElementById('video') as HTMLVideoElement
+      if (!video) return
+      video.srcObject = camera.getStream()
+    }
 
     setResolution({ width: w, height: h })
     storage.setVideoResolution(w, h)

--- a/desktop/src/renderer/src/components/menu/video/sharpness.tsx
+++ b/desktop/src/renderer/src/components/menu/video/sharpness.tsx
@@ -1,0 +1,40 @@
+import { ReactElement } from 'react'
+import { Popover, Slider } from 'antd'
+import { useAtom, useAtomValue } from 'jotai'
+import { WandSparklesIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { captureModeAtom, sharpnessAtom } from '@renderer/jotai/device'
+import { captureCamera } from '@renderer/libs/capture/capture-camera'
+import * as storage from '@renderer/libs/storage'
+
+// Sharpening strength (contrast-adaptive) for the uncompressed capture canvas.
+export const Sharpness = (): ReactElement | null => {
+  const { t } = useTranslation()
+  const captureMode = useAtomValue(captureModeAtom)
+  const [sharpness, setSharpness] = useAtom(sharpnessAtom)
+
+  if (!captureMode) return null
+
+  function update(value: number): void {
+    const v = value / 100
+    setSharpness(v)
+    storage.setSharpness(v)
+    captureCamera.setSharpness(v)
+  }
+
+  const content = (
+    <div className="w-[180px] px-2">
+      <Slider min={0} max={100} value={Math.round(sharpness * 100)} onChange={update} />
+    </div>
+  )
+
+  return (
+    <Popover content={content} placement="rightTop" arrow={false} align={{ offset: [13, 0] }}>
+      <div className="flex h-[30px] cursor-pointer items-center space-x-2 rounded px-3 text-neutral-300 hover:bg-neutral-700/50">
+        <WandSparklesIcon size={16} />
+        <span className="text-sm select-none">{t('video.sharpness')}</span>
+      </div>
+    </Popover>
+  )
+}

--- a/desktop/src/renderer/src/components/mouse/absolute.tsx
+++ b/desktop/src/renderer/src/components/mouse/absolute.tsx
@@ -31,13 +31,16 @@ export const Absolute = (): ReactElement => {
       const clientX = event.clientX
       const clientY = event.clientY
 
-      if (!screen.videoWidth || !screen.videoHeight) {
+      // capture mode renders a <canvas> (no videoWidth); fall back to its buffer size
+      const iw = screen.videoWidth || screen.width
+      const ih = screen.videoHeight || screen.height
+      if (!iw || !ih) {
         const x = (clientX - rect.left) / rect.width
         const y = (clientY - rect.top) / rect.height
         return { x, y }
       }
 
-      const videoRatio = screen.videoWidth / screen.videoHeight
+      const videoRatio = iw / ih
       const elementRatio = rect.width / rect.height
 
       let renderedWidth = rect.width

--- a/desktop/src/renderer/src/i18n/locales/be.ts
+++ b/desktop/src/renderer/src/i18n/locales/be.ts
@@ -28,6 +28,10 @@ const be = {
       resolution: 'Resolutie',
       scale: 'Schaal',
       customResolution: 'Aangepast',
+      capture: 'Без сціскання (эксп.)',
+      captureFailed: 'Захоп без сціскання не ўдаўся',
+      captureDevice: 'Прылада захопу',
+      sharpness: 'Рэзкасць',
       device: 'Toestel',
       custom: {
         title: 'Aangepaste resolutie',

--- a/desktop/src/renderer/src/i18n/locales/de.ts
+++ b/desktop/src/renderer/src/i18n/locales/de.ts
@@ -28,6 +28,10 @@ const de = {
       resolution: 'Auflösung',
       scale: 'Skalierung',
       customResolution: 'Benutzerdefiniert',
+      capture: 'Unkomprimiert (exp.)',
+      captureFailed: 'Unkomprimierte Aufnahme fehlgeschlagen',
+      captureDevice: 'Aufnahmegerät',
+      sharpness: 'Schärfe',
       device: 'Gerät',
       custom: {
         title: 'Benutzerdefinierte Aufösung',

--- a/desktop/src/renderer/src/i18n/locales/en.ts
+++ b/desktop/src/renderer/src/i18n/locales/en.ts
@@ -28,6 +28,10 @@ const en = {
       resolution: 'Resolution',
       scale: 'Scale',
       customResolution: 'Custom',
+      capture: 'Uncompressed (exp.)',
+      captureFailed: 'Uncompressed capture failed',
+      captureDevice: 'Capture Device',
+      sharpness: 'Sharpness',
       device: 'Device',
       custom: {
         title: 'Custom Resolution',

--- a/desktop/src/renderer/src/i18n/locales/ja.ts
+++ b/desktop/src/renderer/src/i18n/locales/ja.ts
@@ -28,6 +28,10 @@ const ja = {
       resolution: '解像度',
       scale: '拡大縮小',
       customResolution: 'カスタム',
+      capture: '非圧縮（実験的）',
+      captureFailed: '非圧縮キャプチャに失敗しました',
+      captureDevice: 'キャプチャデバイス',
+      sharpness: 'シャープネス',
       device: 'デバイス',
       custom: {
         title: 'カスタム解像度',

--- a/desktop/src/renderer/src/i18n/locales/ko.ts
+++ b/desktop/src/renderer/src/i18n/locales/ko.ts
@@ -20,6 +20,10 @@ const ko = {
       resolution: '해상도',
       scale: '배율',
       customResolution: '사용자 정의',
+      capture: '무압축 (실험적)',
+      captureFailed: '무압축 캡처 실패',
+      captureDevice: '캡처 장치',
+      sharpness: '선명도',
       device: '장치',
       custom: {
         title: '사용자 정의 해상도',

--- a/desktop/src/renderer/src/i18n/locales/nl.ts
+++ b/desktop/src/renderer/src/i18n/locales/nl.ts
@@ -28,6 +28,10 @@ const nl = {
       resolution: 'Resolutie',
       scale: 'Schaal',
       customResolution: 'Aangepast',
+      capture: 'Ongecomprimeerd (exp.)',
+      captureFailed: 'Ongecomprimeerde opname mislukt',
+      captureDevice: 'Opnameapparaat',
+      sharpness: 'Scherpte',
       device: 'Apparaat',
       custom: {
         title: 'Aangepaste resolutie',

--- a/desktop/src/renderer/src/i18n/locales/pl.ts
+++ b/desktop/src/renderer/src/i18n/locales/pl.ts
@@ -20,6 +20,10 @@ const pl = {
     video: {
       resolution: 'Rozdzielczość',
       customResolution: 'Niestandardowa',
+      capture: 'Bez kompresji (eksp.)',
+      captureFailed: 'Przechwytywanie bez kompresji nie powiodło się',
+      captureDevice: 'Urządzenie przechwytujące',
+      sharpness: 'Ostrość',
       device: 'Urządzenie',
       custom: {
         title: 'Niestandardowa rozdzielczość',

--- a/desktop/src/renderer/src/i18n/locales/pt_br.ts
+++ b/desktop/src/renderer/src/i18n/locales/pt_br.ts
@@ -20,6 +20,10 @@ const pt_br = {
     video: {
       resolution: 'Resolução',
       customResolution: 'Personalizada',
+      capture: 'Sem compressão (exp.)',
+      captureFailed: 'Falha na captura sem compressão',
+      captureDevice: 'Dispositivo de captura',
+      sharpness: 'Nitidez',
       device: 'Dispositivo',
       custom: {
         title: 'Resolução Personalizada',

--- a/desktop/src/renderer/src/i18n/locales/ru.ts
+++ b/desktop/src/renderer/src/i18n/locales/ru.ts
@@ -28,6 +28,10 @@ const ru = {
       resolution: 'Разрешение',
       scale: 'Масштаб',
       customResolution: 'Пользовательское',
+      capture: 'Без сжатия (эксп.)',
+      captureFailed: 'Сбой захвата без сжатия',
+      captureDevice: 'Устройство захвата',
+      sharpness: 'Резкость',
       device: 'Видеоустройство',
       custom: {
         title: 'Пользовательское разрешение',

--- a/desktop/src/renderer/src/i18n/locales/zh.ts
+++ b/desktop/src/renderer/src/i18n/locales/zh.ts
@@ -27,6 +27,10 @@ const zh = {
       resolution: '分辨率',
       scale: '缩放',
       customResolution: '自定义',
+      capture: '无压缩（实验性）',
+      captureFailed: '无压缩采集失败',
+      captureDevice: '采集设备',
+      sharpness: '锐度',
       device: '设备',
       custom: {
         title: '自定义分辨率',

--- a/desktop/src/renderer/src/i18n/locales/zh_tw.ts
+++ b/desktop/src/renderer/src/i18n/locales/zh_tw.ts
@@ -23,6 +23,10 @@ const zh_tw = {
     video: {
       resolution: '解析度',
       customResolution: '自訂',
+      capture: '無壓縮（實驗性）',
+      captureFailed: '無壓縮擷取失敗',
+      captureDevice: '擷取裝置',
+      sharpness: '銳利度',
       device: '裝置',
       custom: {
         title: '自訂解析度',

--- a/desktop/src/renderer/src/jotai/device.ts
+++ b/desktop/src/renderer/src/jotai/device.ts
@@ -12,6 +12,10 @@ export const resolutionAtom = atom<Resolution>({
 
 export const videoScaleAtom = atom<number>(1.0)
 
+// Experimental: capture the device uncompressed (YUY2) via FFmpeg instead of
+// getUserMedia (which forces MJPEG). macOS only for now.
+export const captureModeAtom = atom<boolean>(false)
+
 export const videoDeviceIdAtom = atom('')
 export const videoStateAtom = atom<VideoState>('disconnected')
 

--- a/desktop/src/renderer/src/jotai/device.ts
+++ b/desktop/src/renderer/src/jotai/device.ts
@@ -15,6 +15,8 @@ export const videoScaleAtom = atom<number>(1.0)
 // Experimental: capture the device uncompressed (YUY2) via FFmpeg instead of
 // getUserMedia (which forces MJPEG). macOS only for now.
 export const captureModeAtom = atom<boolean>(false)
+export const captureDeviceAtom = atom<string>('')
+export const sharpnessAtom = atom<number>(0.5)
 
 export const videoDeviceIdAtom = atom('')
 export const videoStateAtom = atom<VideoState>('disconnected')

--- a/desktop/src/renderer/src/libs/capture/capture-camera.ts
+++ b/desktop/src/renderer/src/libs/capture/capture-camera.ts
@@ -1,6 +1,6 @@
-// Renderer-side controller for the FFmpeg uncompressed-capture path. Mirrors the
+// Renderer-side controller for the uncompressed-capture path. Mirrors the
 // shape of libs/media/camera.ts (open/close/isOpen) but, instead of a MediaStream
-// on a <video>, it drives a WebGL <canvas> fed raw uyvy422 frames from the main
+// on a <video>, it drives a WebGL <canvas> fed raw YUY2 frames from the main
 // process over a MessagePort.
 import { IpcEvents } from '@common/ipc-events'
 
@@ -11,7 +11,8 @@ type OpenOptions = {
   width: number
   height: number
   fps: number
-  deviceIndex?: number
+  deviceName?: string
+  sharpness?: number
   onError?: (msg: string) => void
 }
 
@@ -25,7 +26,7 @@ type FrameMessage = {
 
 let nextRequestId = 0
 
-class FfmpegCamera {
+class CaptureCamera {
   private renderer: YuvRenderer | null = null
   private port: MessagePort | null = null
   private canvas: HTMLCanvasElement | null = null
@@ -35,11 +36,13 @@ class FfmpegCamera {
   private latestFrame: Uint8Array | null = null
   private frameDirty = false
   private rafId = 0
+  private sharpness = 0.5
 
   async open(opts: OpenOptions): Promise<void> {
     this.close()
     this.canvas = opts.canvas
     this.onError = opts.onError
+    if (opts.sharpness !== undefined) this.sharpness = opts.sharpness
     const requestId = ++nextRequestId
 
     window.electron.ipcRenderer.on(IpcEvents.CAPTURE_ERROR, this.handleError)
@@ -50,11 +53,10 @@ class FfmpegCamera {
       this.onPortMessage = (e: MessageEvent): void => {
         if (!e.data || e.data.type !== 'capture-port') return
         if (e.data.meta?.requestId !== requestId) {
-          console.log('capture: ignoring stale port', e.data.meta)
+          // port from a superseded start request
           e.ports[0]?.close()
           return
         }
-        console.log('capture: port received', e.data.meta, 'ports=', e.ports.length)
         window.removeEventListener('message', this.onPortMessage as EventListener)
         this.onPortMessage = null
         this.attachPort(e.ports[0], e.data.meta.width, e.data.meta.height)
@@ -63,10 +65,9 @@ class FfmpegCamera {
       window.addEventListener('message', this.onPortMessage as EventListener)
     })
 
-    console.log('capture: invoking START_CAPTURE', opts.width, opts.height, 'req', requestId)
     try {
       await window.electron.ipcRenderer.invoke(IpcEvents.START_CAPTURE, {
-        deviceIndex: opts.deviceIndex,
+        deviceName: opts.deviceName,
         width: opts.width,
         height: opts.height,
         fps: opts.fps,
@@ -82,7 +83,6 @@ class FfmpegCamera {
   }
 
   private attachPort(port: MessagePort, width: number, height: number): void {
-    console.log('capture: attachPort canvas=', !!this.canvas, width, height)
     if (!this.canvas) {
       this.handleError('capture canvas not found')
       return
@@ -92,12 +92,11 @@ class FfmpegCamera {
       this.handleError('WebGL2 unavailable')
       return
     }
+    this.renderer.setSharpness(this.sharpness)
     this.port = port
-    let recv = 0
     port.onmessage = (e: MessageEvent<FrameMessage>): void => {
       this.latestFrame = new Uint8Array(e.data.buf)
       this.frameDirty = true
-      if (++recv % 60 === 0) console.log('capture-debug renderer received', recv)
     }
     port.start()
 
@@ -106,45 +105,16 @@ class FfmpegCamera {
     // canvas — the buffer is cleared before it's composited. Only draw when a
     // new frame arrived, and ack it afterwards so main sends the next one —
     // this paces delivery to what we can actually render (see backpressure
-    // note in main/capture/ffmpeg.ts).
-    let rendered = 0
+    // note in main/capture/engine.ts).
     const loop = (): void => {
       if (this.frameDirty && this.latestFrame && this.renderer && this.port) {
         this.renderer.render(this.latestFrame)
         this.frameDirty = false
         this.port.postMessage(1)
-        if (++rendered % 60 === 0) {
-          // TEMP (debug): checksum of the incoming frame + readback of the drawn
-          // pixel — proves whether source content and displayed content are live.
-          let sum = 0
-          for (let i = 0; i < 4096; i++) sum = (sum + this.latestFrame[i * 500]) | 0
-          console.log(
-            'capture-debug rendered',
-            rendered,
-            'frameSum=',
-            sum,
-            this.renderer.probe()
-          )
-        }
       }
       this.rafId = requestAnimationFrame(loop)
     }
     this.rafId = requestAnimationFrame(loop)
-
-    setTimeout(() => {
-      const c = this.canvas
-      if (c)
-        console.log(
-          'capture: canvas buffer',
-          c.width,
-          c.height,
-          'display',
-          c.clientWidth,
-          c.clientHeight,
-          'dpr',
-          window.devicePixelRatio
-        )
-    }, 800)
   }
 
   close(): void {
@@ -177,10 +147,15 @@ class FfmpegCamera {
     return this.open_
   }
 
+  setSharpness(value: number): void {
+    this.sharpness = value
+    this.renderer?.setSharpness(value)
+  }
+
   private handleError = (...args: unknown[]): void => {
     const text = args.find((a) => typeof a === 'string') as string | undefined
     this.onError?.(text || 'capture error')
   }
 }
 
-export const ffmpegCamera = new FfmpegCamera()
+export const captureCamera = new CaptureCamera()

--- a/desktop/src/renderer/src/libs/capture/ffmpeg-camera.ts
+++ b/desktop/src/renderer/src/libs/capture/ffmpeg-camera.ts
@@ -1,0 +1,186 @@
+// Renderer-side controller for the FFmpeg uncompressed-capture path. Mirrors the
+// shape of libs/media/camera.ts (open/close/isOpen) but, instead of a MediaStream
+// on a <video>, it drives a WebGL <canvas> fed raw uyvy422 frames from the main
+// process over a MessagePort.
+import { IpcEvents } from '@common/ipc-events'
+
+import { YuvRenderer } from './yuv-renderer'
+
+type OpenOptions = {
+  canvas: HTMLCanvasElement
+  width: number
+  height: number
+  fps: number
+  deviceIndex?: number
+  onError?: (msg: string) => void
+}
+
+type FrameMessage = {
+  seq: number
+  emitAbs: number
+  width: number
+  height: number
+  buf: ArrayBuffer
+}
+
+let nextRequestId = 0
+
+class FfmpegCamera {
+  private renderer: YuvRenderer | null = null
+  private port: MessagePort | null = null
+  private canvas: HTMLCanvasElement | null = null
+  private onPortMessage: ((e: MessageEvent) => void) | null = null
+  private onError?: (msg: string) => void
+  private open_ = false
+  private latestFrame: Uint8Array | null = null
+  private frameDirty = false
+  private rafId = 0
+
+  async open(opts: OpenOptions): Promise<void> {
+    this.close()
+    this.canvas = opts.canvas
+    this.onError = opts.onError
+    const requestId = ++nextRequestId
+
+    window.electron.ipcRenderer.on(IpcEvents.CAPTURE_ERROR, this.handleError)
+
+    // Receive the transferred MessagePort forwarded by the preload. Match on
+    // requestId — a port from a superseded start request must not be attached.
+    const portReceived = new Promise<void>((resolve) => {
+      this.onPortMessage = (e: MessageEvent): void => {
+        if (!e.data || e.data.type !== 'capture-port') return
+        if (e.data.meta?.requestId !== requestId) {
+          console.log('capture: ignoring stale port', e.data.meta)
+          e.ports[0]?.close()
+          return
+        }
+        console.log('capture: port received', e.data.meta, 'ports=', e.ports.length)
+        window.removeEventListener('message', this.onPortMessage as EventListener)
+        this.onPortMessage = null
+        this.attachPort(e.ports[0], e.data.meta.width, e.data.meta.height)
+        resolve()
+      }
+      window.addEventListener('message', this.onPortMessage as EventListener)
+    })
+
+    console.log('capture: invoking START_CAPTURE', opts.width, opts.height, 'req', requestId)
+    try {
+      await window.electron.ipcRenderer.invoke(IpcEvents.START_CAPTURE, {
+        deviceIndex: opts.deviceIndex,
+        width: opts.width,
+        height: opts.height,
+        fps: opts.fps,
+        requestId
+      })
+    } catch (err) {
+      this.close()
+      throw err
+    }
+    await portReceived
+
+    this.open_ = true
+  }
+
+  private attachPort(port: MessagePort, width: number, height: number): void {
+    console.log('capture: attachPort canvas=', !!this.canvas, width, height)
+    if (!this.canvas) {
+      this.handleError('capture canvas not found')
+      return
+    }
+    this.renderer = new YuvRenderer()
+    if (!this.renderer.init(this.canvas, width, height)) {
+      this.handleError('WebGL2 unavailable')
+      return
+    }
+    this.port = port
+    let recv = 0
+    port.onmessage = (e: MessageEvent<FrameMessage>): void => {
+      this.latestFrame = new Uint8Array(e.data.buf)
+      this.frameDirty = true
+      if (++recv % 60 === 0) console.log('capture-debug renderer received', recv)
+    }
+    port.start()
+
+    // Render in sync with the compositor. Drawing on message arrival (outside
+    // requestAnimationFrame) with preserveDrawingBuffer:false shows a black
+    // canvas — the buffer is cleared before it's composited. Only draw when a
+    // new frame arrived, and ack it afterwards so main sends the next one —
+    // this paces delivery to what we can actually render (see backpressure
+    // note in main/capture/ffmpeg.ts).
+    let rendered = 0
+    const loop = (): void => {
+      if (this.frameDirty && this.latestFrame && this.renderer && this.port) {
+        this.renderer.render(this.latestFrame)
+        this.frameDirty = false
+        this.port.postMessage(1)
+        if (++rendered % 60 === 0) {
+          // TEMP (debug): checksum of the incoming frame + readback of the drawn
+          // pixel — proves whether source content and displayed content are live.
+          let sum = 0
+          for (let i = 0; i < 4096; i++) sum = (sum + this.latestFrame[i * 500]) | 0
+          console.log(
+            'capture-debug rendered',
+            rendered,
+            'frameSum=',
+            sum,
+            this.renderer.probe()
+          )
+        }
+      }
+      this.rafId = requestAnimationFrame(loop)
+    }
+    this.rafId = requestAnimationFrame(loop)
+
+    setTimeout(() => {
+      const c = this.canvas
+      if (c)
+        console.log(
+          'capture: canvas buffer',
+          c.width,
+          c.height,
+          'display',
+          c.clientWidth,
+          c.clientHeight,
+          'dpr',
+          window.devicePixelRatio
+        )
+    }, 800)
+  }
+
+  close(): void {
+    window.electron.ipcRenderer.invoke(IpcEvents.STOP_CAPTURE)
+    window.electron.ipcRenderer.removeAllListeners(IpcEvents.CAPTURE_ERROR)
+    if (this.rafId) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = 0
+    }
+    this.latestFrame = null
+    this.frameDirty = false
+    if (this.onPortMessage) {
+      window.removeEventListener('message', this.onPortMessage as EventListener)
+      this.onPortMessage = null
+    }
+    if (this.port) {
+      this.port.onmessage = null
+      this.port.close()
+      this.port = null
+    }
+    if (this.renderer) {
+      this.renderer.dispose()
+      this.renderer = null
+    }
+    this.canvas = null
+    this.open_ = false
+  }
+
+  isOpen(): boolean {
+    return this.open_
+  }
+
+  private handleError = (...args: unknown[]): void => {
+    const text = args.find((a) => typeof a === 'string') as string | undefined
+    this.onError?.(text || 'capture error')
+  }
+}
+
+export const ffmpegCamera = new FfmpegCamera()

--- a/desktop/src/renderer/src/libs/capture/yuv-renderer.ts
+++ b/desktop/src/renderer/src/libs/capture/yuv-renderer.ts
@@ -3,17 +3,16 @@
 // path, which delivers raw frames that a plain <video> can't display.
 //
 // Two-pass for display quality: pass 1 converts YUY2→RGB at source size into a
-// framebuffer texture; pass 2 blits it with LINEAR filtering to a canvas buffer
-// at 2x source size. The browser then bilinearly *downscales* to the displayed
-// size, which stays sharp — a direct nearest/bilinear upscale of the source
-// buffer looks jagged/soft at non-integer HiDPI scale factors.
-
-const SUPERSAMPLE = 2
+// framebuffer texture; pass 2 resamples it with Catmull-Rom bicubic directly
+// into a canvas buffer matched to the element's PHYSICAL pixel size
+// (clientWidth × devicePixelRatio). Rendering 1:1 with the display and using
+// bicubic (instead of bilinear, which smears text) keeps fractional upscales
+// as crisp as they can be — the browser never resamples the result.
 
 const VERT = `#version 300 es
 void main(){ vec2 v[3]=vec2[3](vec2(-1.,-1.),vec2(3.,-1.),vec2(-1.,3.)); gl_Position=vec4(v[gl_VertexID],0.,1.); }`
 
-const FRAG = `#version 300 es
+const FRAG_YUV = `#version 300 es
 precision highp float; precision highp int;
 uniform highp usampler2D tex; uniform int uH;
 out vec4 frag;
@@ -27,8 +26,64 @@ void main(){
   frag=vec4(clamp(vec3(r,g,b)/255.0,0.0,1.0),1.0);
 }`
 
+// Catmull-Rom bicubic via 9 bilinear fetches (Jimenez).
+const FRAG_SCALE = `#version 300 es
+precision highp float;
+uniform sampler2D tex; uniform vec2 uSrcSize; uniform vec2 uOutSize;
+out vec4 frag;
+vec4 catmullRom(vec2 uv){
+  vec2 samplePos = uv * uSrcSize;
+  vec2 texPos1 = floor(samplePos - 0.5) + 0.5;
+  vec2 f = samplePos - texPos1;
+  vec2 w0 = f * (-0.5 + f * (1.0 - 0.5 * f));
+  vec2 w1 = 1.0 + f * f * (-2.5 + 1.5 * f);
+  vec2 w2 = f * (0.5 + f * (2.0 - 1.5 * f));
+  vec2 w3 = f * f * (-0.5 + 0.5 * f);
+  vec2 w12 = w1 + w2;
+  vec2 tc0 = (texPos1 - 1.0) / uSrcSize;
+  vec2 tc3 = (texPos1 + 2.0) / uSrcSize;
+  vec2 tc12 = (texPos1 + w2 / w12) / uSrcSize;
+  vec4 r = vec4(0.0);
+  r += texture(tex, vec2(tc0.x,  tc0.y))  * w0.x  * w0.y;
+  r += texture(tex, vec2(tc12.x, tc0.y))  * w12.x * w0.y;
+  r += texture(tex, vec2(tc3.x,  tc0.y))  * w3.x  * w0.y;
+  r += texture(tex, vec2(tc0.x,  tc12.y)) * w0.x  * w12.y;
+  r += texture(tex, vec2(tc12.x, tc12.y)) * w12.x * w12.y;
+  r += texture(tex, vec2(tc3.x,  tc12.y)) * w3.x  * w12.y;
+  r += texture(tex, vec2(tc0.x,  tc3.y))  * w0.x  * w3.y;
+  r += texture(tex, vec2(tc12.x, tc3.y))  * w12.x * w3.y;
+  r += texture(tex, vec2(tc3.x,  tc3.y))  * w3.x  * w3.y;
+  return r;
+}
+void main(){
+  // pass-1 output is already display-oriented; sample straight through
+  vec2 uv = gl_FragCoord.xy / uOutSize;
+  vec3 c = clamp(catmullRom(uv).rgb, 0.0, 1.0);
+
+  // Contrast-adaptive sharpening (AMD CAS-style): sharpen flat/low-contrast
+  // areas, back off at already-hard edges to avoid halos.
+  vec2 d = 1.0 / uOutSize;
+  vec3 n = texture(tex, uv + vec2( 0.0, -d.y)).rgb;
+  vec3 s = texture(tex, uv + vec2( 0.0,  d.y)).rgb;
+  vec3 e = texture(tex, uv + vec2( d.x,  0.0)).rgb;
+  vec3 w = texture(tex, uv + vec2(-d.x,  0.0)).rgb;
+  vec3 mn = min(min(min(n, s), min(e, w)), c);
+  vec3 mx = max(max(max(n, s), max(e, w)), c);
+  vec3 amp = sqrt(clamp(min(mn, 1.0 - mx) / max(mx, vec3(1e-4)), 0.0, 1.0));
+  float sharpness = 0.5;                       // 0..1
+  vec3 wgt = amp * (-1.0 / mix(8.0, 5.0, sharpness));
+  vec3 outc = ((n + s + e + w) * wgt + c) / (4.0 * wgt + 1.0);
+
+  frag = vec4(clamp(outc, 0.0, 1.0), 1.0);
+}`
+
 export class YuvRenderer {
   private gl: WebGL2RenderingContext | null = null
+  private canvas: HTMLCanvasElement | null = null
+  private progYuv: WebGLProgram | null = null
+  private progScale: WebGLProgram | null = null
+  private uSrcSize: WebGLUniformLocation | null = null
+  private uOutSize: WebGLUniformLocation | null = null
   private tex: WebGLTexture | null = null
   private rgbTex: WebGLTexture | null = null
   private fbo: WebGLFramebuffer | null = null
@@ -36,20 +91,32 @@ export class YuvRenderer {
   private height = 0
 
   init(canvas: HTMLCanvasElement, width: number, height: number): boolean {
+    this.canvas = canvas
     this.width = width
     this.height = height
-    canvas.width = width * SUPERSAMPLE
-    canvas.height = height * SUPERSAMPLE
+    // Keep the element's box at the source aspect; the buffer follows the
+    // element's physical size (see syncSize) so display is always 1:1 pixels.
+    canvas.style.aspectRatio = `${width} / ${height}`
+    canvas.width = width
+    canvas.height = height
 
     const gl = canvas.getContext('webgl2', { antialias: false, preserveDrawingBuffer: false })
     if (!gl) return false
     this.gl = gl
 
-    const prog = this.link(gl, VERT, FRAG)
-    if (!prog) return false
-    gl.useProgram(prog)
-    gl.uniform1i(gl.getUniformLocation(prog, 'tex'), 0)
-    gl.uniform1i(gl.getUniformLocation(prog, 'uH'), height)
+    this.progYuv = this.link(gl, VERT, FRAG_YUV)
+    this.progScale = this.link(gl, VERT, FRAG_SCALE)
+    if (!this.progYuv || !this.progScale) return false
+
+    gl.useProgram(this.progYuv)
+    gl.uniform1i(gl.getUniformLocation(this.progYuv, 'tex'), 0)
+    gl.uniform1i(gl.getUniformLocation(this.progYuv, 'uH'), height)
+
+    gl.useProgram(this.progScale)
+    gl.uniform1i(gl.getUniformLocation(this.progScale, 'tex'), 0)
+    this.uSrcSize = gl.getUniformLocation(this.progScale, 'uSrcSize')
+    this.uOutSize = gl.getUniformLocation(this.progScale, 'uOutSize')
+    gl.uniform2f(this.uSrcSize, width, height)
 
     // Source YUY2 texture (integer, exact texel reads in the shader).
     // Immutable storage — per-frame uploads use texSubImage2D (no realloc).
@@ -61,7 +128,7 @@ export class YuvRenderer {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
-    // Intermediate RGB target at source size for the pass-2 linear blit.
+    // Intermediate RGB target at source size; LINEAR enables the 9-tap trick.
     this.rgbTex = gl.createTexture()
     gl.bindTexture(gl.TEXTURE_2D, this.rgbTex)
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
@@ -81,11 +148,26 @@ export class YuvRenderer {
     return true
   }
 
+  // Match the drawing buffer to the element's physical pixels.
+  private syncSize(): void {
+    const c = this.canvas
+    if (!c) return
+    const dpr = window.devicePixelRatio || 1
+    const w = Math.max(1, Math.round(c.clientWidth * dpr))
+    const h = Math.max(1, Math.round(c.clientHeight * dpr))
+    if (c.width !== w || c.height !== h) {
+      c.width = w
+      c.height = h
+    }
+  }
+
   render(frame: Uint8Array): void {
     const gl = this.gl
     if (!gl) return
+    this.syncSize()
 
     // Pass 1: YUY2 -> RGB at source size, into the FBO.
+    gl.useProgram(this.progYuv)
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo)
     gl.viewport(0, 0, this.width, this.height)
     gl.bindTexture(gl.TEXTURE_2D, this.tex)
@@ -102,21 +184,15 @@ export class YuvRenderer {
     )
     gl.drawArrays(gl.TRIANGLES, 0, 3)
 
-    // Pass 2: linear blit up to the supersampled backbuffer.
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this.fbo)
-    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null)
-    gl.blitFramebuffer(
-      0,
-      0,
-      this.width,
-      this.height,
-      0,
-      0,
-      this.width * SUPERSAMPLE,
-      this.height * SUPERSAMPLE,
-      gl.COLOR_BUFFER_BIT,
-      gl.LINEAR
-    )
+    // Pass 2: bicubic resample to the physical-pixel backbuffer.
+    const outW = gl.drawingBufferWidth
+    const outH = gl.drawingBufferHeight
+    gl.useProgram(this.progScale)
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+    gl.viewport(0, 0, outW, outH)
+    gl.uniform2f(this.uOutSize, outW, outH)
+    gl.bindTexture(gl.TEXTURE_2D, this.rgbTex)
+    gl.drawArrays(gl.TRIANGLES, 0, 3)
   }
 
   // TEMP (debug): read back one pixel from the drawn backbuffer to prove the
@@ -126,11 +202,17 @@ export class YuvRenderer {
     const gl = this.gl
     if (!gl) return 'no-gl'
     if (gl.isContextLost()) return 'CONTEXT-LOST'
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null) // read the displayed backbuffer
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null)
     const px = new Uint8Array(4)
-    const cx = Math.floor((this.width * SUPERSAMPLE) / 2)
-    const cy = Math.floor((this.height * SUPERSAMPLE) / 2)
-    gl.readPixels(cx, cy, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px)
+    gl.readPixels(
+      Math.floor(gl.drawingBufferWidth / 2),
+      Math.floor(gl.drawingBufferHeight / 2),
+      1,
+      1,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      px
+    )
     const err = gl.getError()
     return `px=${px.join(',')}${err ? ` glErr=${err}` : ''}`
   }
@@ -143,6 +225,7 @@ export class YuvRenderer {
       if (this.fbo) gl.deleteFramebuffer(this.fbo)
     }
     this.gl = null
+    this.canvas = null
     this.tex = null
     this.rgbTex = null
     this.fbo = null

--- a/desktop/src/renderer/src/libs/capture/yuv-renderer.ts
+++ b/desktop/src/renderer/src/libs/capture/yuv-renderer.ts
@@ -29,7 +29,7 @@ void main(){
 // Catmull-Rom bicubic via 9 bilinear fetches (Jimenez).
 const FRAG_SCALE = `#version 300 es
 precision highp float;
-uniform sampler2D tex; uniform vec2 uSrcSize; uniform vec2 uOutSize;
+uniform sampler2D tex; uniform vec2 uSrcSize; uniform vec2 uOutSize; uniform float uSharp;
 out vec4 frag;
 vec4 catmullRom(vec2 uv){
   vec2 samplePos = uv * uSrcSize;
@@ -70,11 +70,11 @@ void main(){
   vec3 mn = min(min(min(n, s), min(e, w)), c);
   vec3 mx = max(max(max(n, s), max(e, w)), c);
   vec3 amp = sqrt(clamp(min(mn, 1.0 - mx) / max(mx, vec3(1e-4)), 0.0, 1.0));
-  float sharpness = 0.5;                       // 0..1
-  vec3 wgt = amp * (-1.0 / mix(8.0, 5.0, sharpness));
+  vec3 wgt = amp * (-1.0 / 5.0);
   vec3 outc = ((n + s + e + w) * wgt + c) / (4.0 * wgt + 1.0);
 
-  frag = vec4(clamp(outc, 0.0, 1.0), 1.0);
+  // uSharp 0..1 blends from unsharpened to full-strength CAS.
+  frag = vec4(clamp(mix(c, outc, uSharp), 0.0, 1.0), 1.0);
 }`
 
 export class YuvRenderer {
@@ -84,6 +84,8 @@ export class YuvRenderer {
   private progScale: WebGLProgram | null = null
   private uSrcSize: WebGLUniformLocation | null = null
   private uOutSize: WebGLUniformLocation | null = null
+  private uSharp: WebGLUniformLocation | null = null
+  private sharpness = 0.5
   private tex: WebGLTexture | null = null
   private rgbTex: WebGLTexture | null = null
   private fbo: WebGLFramebuffer | null = null
@@ -116,6 +118,7 @@ export class YuvRenderer {
     gl.uniform1i(gl.getUniformLocation(this.progScale, 'tex'), 0)
     this.uSrcSize = gl.getUniformLocation(this.progScale, 'uSrcSize')
     this.uOutSize = gl.getUniformLocation(this.progScale, 'uOutSize')
+    this.uSharp = gl.getUniformLocation(this.progScale, 'uSharp')
     gl.uniform2f(this.uSrcSize, width, height)
 
     // Source YUY2 texture (integer, exact texel reads in the shader).
@@ -191,30 +194,13 @@ export class YuvRenderer {
     gl.bindFramebuffer(gl.FRAMEBUFFER, null)
     gl.viewport(0, 0, outW, outH)
     gl.uniform2f(this.uOutSize, outW, outH)
+    gl.uniform1f(this.uSharp, this.sharpness)
     gl.bindTexture(gl.TEXTURE_2D, this.rgbTex)
     gl.drawArrays(gl.TRIANGLES, 0, 3)
   }
 
-  // TEMP (debug): read back one pixel from the drawn backbuffer to prove the
-  // displayed content is actually updating. Must be called right after render()
-  // within the same rAF callback (preserveDrawingBuffer is false).
-  probe(): string {
-    const gl = this.gl
-    if (!gl) return 'no-gl'
-    if (gl.isContextLost()) return 'CONTEXT-LOST'
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null)
-    const px = new Uint8Array(4)
-    gl.readPixels(
-      Math.floor(gl.drawingBufferWidth / 2),
-      Math.floor(gl.drawingBufferHeight / 2),
-      1,
-      1,
-      gl.RGBA,
-      gl.UNSIGNED_BYTE,
-      px
-    )
-    const err = gl.getError()
-    return `px=${px.join(',')}${err ? ` glErr=${err}` : ''}`
+  setSharpness(value: number): void {
+    this.sharpness = Math.min(1, Math.max(0, value))
   }
 
   dispose(): void {

--- a/desktop/src/renderer/src/libs/capture/yuv-renderer.ts
+++ b/desktop/src/renderer/src/libs/capture/yuv-renderer.ts
@@ -1,0 +1,177 @@
+// WebGL2 renderer: uploads a yuvs (YUY2) frame to an integer texture and
+// converts it to RGB in a fragment shader. Used by the uncompressed capture
+// path, which delivers raw frames that a plain <video> can't display.
+//
+// Two-pass for display quality: pass 1 converts YUY2→RGB at source size into a
+// framebuffer texture; pass 2 blits it with LINEAR filtering to a canvas buffer
+// at 2x source size. The browser then bilinearly *downscales* to the displayed
+// size, which stays sharp — a direct nearest/bilinear upscale of the source
+// buffer looks jagged/soft at non-integer HiDPI scale factors.
+
+const SUPERSAMPLE = 2
+
+const VERT = `#version 300 es
+void main(){ vec2 v[3]=vec2[3](vec2(-1.,-1.),vec2(3.,-1.),vec2(-1.,3.)); gl_Position=vec4(v[gl_VertexID],0.,1.); }`
+
+const FRAG = `#version 300 es
+precision highp float; precision highp int;
+uniform highp usampler2D tex; uniform int uH;
+out vec4 frag;
+void main(){
+  int x=int(gl_FragCoord.x); int y=uH-1-int(gl_FragCoord.y); int mp=x>>1;
+  uvec4 t=texelFetch(tex, ivec2(mp,y), 0);        // yuvs: Y0 U Y1 V
+  float U=float(t.g), V=float(t.a);
+  float Y=((x&1)==0)?float(t.r):float(t.b);
+  float yy=Y-16.0, uu=U-128.0, vv=V-128.0;
+  float r=1.164*yy+1.596*vv, g=1.164*yy-0.392*uu-0.813*vv, b=1.164*yy+2.017*uu;
+  frag=vec4(clamp(vec3(r,g,b)/255.0,0.0,1.0),1.0);
+}`
+
+export class YuvRenderer {
+  private gl: WebGL2RenderingContext | null = null
+  private tex: WebGLTexture | null = null
+  private rgbTex: WebGLTexture | null = null
+  private fbo: WebGLFramebuffer | null = null
+  private width = 0
+  private height = 0
+
+  init(canvas: HTMLCanvasElement, width: number, height: number): boolean {
+    this.width = width
+    this.height = height
+    canvas.width = width * SUPERSAMPLE
+    canvas.height = height * SUPERSAMPLE
+
+    const gl = canvas.getContext('webgl2', { antialias: false, preserveDrawingBuffer: false })
+    if (!gl) return false
+    this.gl = gl
+
+    const prog = this.link(gl, VERT, FRAG)
+    if (!prog) return false
+    gl.useProgram(prog)
+    gl.uniform1i(gl.getUniformLocation(prog, 'tex'), 0)
+    gl.uniform1i(gl.getUniformLocation(prog, 'uH'), height)
+
+    // Source YUY2 texture (integer, exact texel reads in the shader).
+    // Immutable storage — per-frame uploads use texSubImage2D (no realloc).
+    this.tex = gl.createTexture()
+    gl.bindTexture(gl.TEXTURE_2D, this.tex)
+    gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8UI, width / 2, height)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+
+    // Intermediate RGB target at source size for the pass-2 linear blit.
+    this.rgbTex = gl.createTexture()
+    gl.bindTexture(gl.TEXTURE_2D, this.rgbTex)
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+
+    this.fbo = gl.createFramebuffer()
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo)
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.rgbTex, 0)
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+      console.error('capture framebuffer incomplete')
+      return false
+    }
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null)
+    return true
+  }
+
+  render(frame: Uint8Array): void {
+    const gl = this.gl
+    if (!gl) return
+
+    // Pass 1: YUY2 -> RGB at source size, into the FBO.
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this.fbo)
+    gl.viewport(0, 0, this.width, this.height)
+    gl.bindTexture(gl.TEXTURE_2D, this.tex)
+    gl.texSubImage2D(
+      gl.TEXTURE_2D,
+      0,
+      0,
+      0,
+      this.width / 2,
+      this.height,
+      gl.RGBA_INTEGER,
+      gl.UNSIGNED_BYTE,
+      frame
+    )
+    gl.drawArrays(gl.TRIANGLES, 0, 3)
+
+    // Pass 2: linear blit up to the supersampled backbuffer.
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, this.fbo)
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null)
+    gl.blitFramebuffer(
+      0,
+      0,
+      this.width,
+      this.height,
+      0,
+      0,
+      this.width * SUPERSAMPLE,
+      this.height * SUPERSAMPLE,
+      gl.COLOR_BUFFER_BIT,
+      gl.LINEAR
+    )
+  }
+
+  // TEMP (debug): read back one pixel from the drawn backbuffer to prove the
+  // displayed content is actually updating. Must be called right after render()
+  // within the same rAF callback (preserveDrawingBuffer is false).
+  probe(): string {
+    const gl = this.gl
+    if (!gl) return 'no-gl'
+    if (gl.isContextLost()) return 'CONTEXT-LOST'
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null) // read the displayed backbuffer
+    const px = new Uint8Array(4)
+    const cx = Math.floor((this.width * SUPERSAMPLE) / 2)
+    const cy = Math.floor((this.height * SUPERSAMPLE) / 2)
+    gl.readPixels(cx, cy, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px)
+    const err = gl.getError()
+    return `px=${px.join(',')}${err ? ` glErr=${err}` : ''}`
+  }
+
+  dispose(): void {
+    const gl = this.gl
+    if (gl) {
+      if (this.tex) gl.deleteTexture(this.tex)
+      if (this.rgbTex) gl.deleteTexture(this.rgbTex)
+      if (this.fbo) gl.deleteFramebuffer(this.fbo)
+    }
+    this.gl = null
+    this.tex = null
+    this.rgbTex = null
+    this.fbo = null
+  }
+
+  private link(gl: WebGL2RenderingContext, vs: string, fs: string): WebGLProgram | null {
+    const compile = (type: number, src: string): WebGLShader | null => {
+      const sh = gl.createShader(type)
+      if (!sh) return null
+      gl.shaderSource(sh, src)
+      gl.compileShader(sh)
+      if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+        console.error('shader compile error:', gl.getShaderInfoLog(sh))
+        return null
+      }
+      return sh
+    }
+    const v = compile(gl.VERTEX_SHADER, vs)
+    const f = compile(gl.FRAGMENT_SHADER, fs)
+    if (!v || !f) return null
+    const prog = gl.createProgram()
+    if (!prog) return null
+    gl.attachShader(prog, v)
+    gl.attachShader(prog, f)
+    gl.linkProgram(prog)
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+      console.error('program link error:', gl.getProgramInfoLog(prog))
+      return null
+    }
+    return prog
+  }
+}

--- a/desktop/src/renderer/src/libs/storage/index.ts
+++ b/desktop/src/renderer/src/libs/storage/index.ts
@@ -7,6 +7,8 @@ const VIDEO_DEVICE_ID_KEY = 'nanokvm-usb-video-device-id'
 const VIDEO_RESOLUTION_KEY = 'nanokvm-usb-video-resolution'
 const VIDEO_SCALE_KEY = 'nanokvm-usb-video-scale'
 const CAPTURE_MODE_KEY = 'nanokvm-usb-capture-mode'
+const CAPTURE_DEVICE_KEY = 'nanokvm-usb-capture-device'
+const SHARPNESS_KEY = 'nanokvm-usb-sharpness'
 const CUSTOM_RESOLUTION_KEY = 'nanokvm-usb-custom-resolution'
 const SERIAL_PORT_KEY = 'nanokvm-serial-port'
 const IS_MENU_OPEN_KEY = 'nanokvm-is-menu-open'
@@ -86,6 +88,23 @@ export function getCaptureMode(): boolean {
 
 export function setCaptureMode(enabled: boolean): void {
   localStorage.setItem(CAPTURE_MODE_KEY, enabled ? 'true' : 'false')
+}
+
+export function getCaptureDevice(): string {
+  return localStorage.getItem(CAPTURE_DEVICE_KEY) || ''
+}
+
+export function setCaptureDevice(name: string): void {
+  localStorage.setItem(CAPTURE_DEVICE_KEY, name)
+}
+
+export function getSharpness(): number {
+  const value = Number(localStorage.getItem(SHARPNESS_KEY))
+  return Number.isFinite(value) && localStorage.getItem(SHARPNESS_KEY) !== null ? value : 0.5
+}
+
+export function setSharpness(value: number): void {
+  localStorage.setItem(SHARPNESS_KEY, String(value))
 }
 
 export function getSerialPort(): string | null {

--- a/desktop/src/renderer/src/libs/storage/index.ts
+++ b/desktop/src/renderer/src/libs/storage/index.ts
@@ -6,6 +6,7 @@ const LANGUAGE_KEY = 'nanokvm-usb-language'
 const VIDEO_DEVICE_ID_KEY = 'nanokvm-usb-video-device-id'
 const VIDEO_RESOLUTION_KEY = 'nanokvm-usb-video-resolution'
 const VIDEO_SCALE_KEY = 'nanokvm-usb-video-scale'
+const CAPTURE_MODE_KEY = 'nanokvm-usb-capture-mode'
 const CUSTOM_RESOLUTION_KEY = 'nanokvm-usb-custom-resolution'
 const SERIAL_PORT_KEY = 'nanokvm-serial-port'
 const IS_MENU_OPEN_KEY = 'nanokvm-is-menu-open'
@@ -77,6 +78,14 @@ export function getVideoScale(): number | null {
 
 export function setVideoScale(scale: number): void {
   localStorage.setItem(VIDEO_SCALE_KEY, String(scale))
+}
+
+export function getCaptureMode(): boolean {
+  return localStorage.getItem(CAPTURE_MODE_KEY) === 'true'
+}
+
+export function setCaptureMode(enabled: boolean): void {
+  localStorage.setItem(CAPTURE_MODE_KEY, enabled ? 'true' : 'false')
 }
 
 export function getSerialPort(): string | null {


### PR DESCRIPTION
## Why

Video quality in the desktop app is limited by Chromium, not by the capture hardware. The app captures through `getUserMedia`, which exposes **no pixel-format control** — and for MacroSilicon MS2131 devices Chromium auto-selects **MJPEG** at 1080p. The lossy compression makes text and edges visibly soft, and it is baked into the captured pixels (confirmed soft even at 1:1 pixels with a native-1080p source). OBS on the *same* device looks sharp because it talks to the OS capture API directly and selects **uncompressed YUY2** — proving the chip is not the ceiling; the forced MJPEG is.

This PR adds an **opt-in "Uncompressed (exp.)" video mode** to the desktop app that bypasses `getUserMedia` entirely: raw YUY2 is captured natively, streamed into the renderer, and drawn via WebGL — OBS-class sharpness while keeping the app's keyboard/mouse/serial control untouched. The default `getUserMedia` path is unchanged; the mode is a toggle in the Video menu.

A throwaway PoC validated the approach before the build-out: ~4 ms added pipeline latency (capture → cross-process transport → GPU render), well within interactive KVM tolerance.

## How it works

**Capture (main process)** — `src/main/capture/`:
- A platform backend spawns a capture process that writes raw yuyv422 frames to stdout.
  - **macOS**: a ~100 KB native Swift helper (`native/nanokvm-capture.swift`, AVFoundation). ffmpeg was tried first but its avfoundation input **silently freezes on ≥1080p uncompressed frames** (delivers one frame duplicated at an impossible rate) — a native `AVCaptureSession` works. The helper reports the *actually delivered* dimensions before frames flow (the UVC stack may serve the signal-native mode regardless of the request), locks the format only after 3 stable frames, and exits distinctly on a mid-stream mode change so the app restarts capture (e.g. when the target changes resolution).
  - **Windows**: system ffmpeg via DirectShow. **Linux**: system ffmpeg via V4L2. (`FFMPEG_PATH` overrides; a missing binary surfaces as a clear toast.)
- Devices are selected **by name**, not index — AVFoundation indices shift whenever Apple Continuity cameras (iPhone/Desk View) appear or disappear.
- Frames stream to the renderer over a `MessageChannelMain` with **ack-based backpressure** (one frame in flight, freshest-wins): uncompressed 1080p60 is ~250 MB/s of structured-clone copies, and flooding the port starves the renderer's event loop until keyboard/mouse input goes dead.

**Rendering (renderer)** — `src/renderer/src/libs/capture/`:
- WebGL2 integer-texture shader converts YUY2→RGB at source size, then a second pass resamples with **Catmull-Rom bicubic** directly into a canvas buffer matched to the element's physical pixel size (so the browser never resamples), plus an adjustable **contrast-adaptive sharpening** pass (AMD CAS-style). `backgroundThrottling` is disabled so video keeps updating while the KVM window is not frontmost.

**UI**: Video menu gains the toggle, a Capture Device picker (shown only in capture mode; the `getUserMedia` Device picker hides, since enumerating it opens a competing camera session), and a Sharpness slider. Strings localized across all 11 locales. Capture errors show a toast and fall back to the regular camera instead of breaking the session.

**Packaging**: `build:mac` compiles the Swift helper into `resources/` (asarUnpacked); electron-builder signs it with the app identity + hardened runtime. Local builds without Apple credentials now skip notarization instead of failing (CI still notarizes). Also constrains the `ajv` override to `>=6.14.0 <7` — the open-ended range pulled ajv 8 into ajv-6-only consumers and broke electron-builder.

## Test status

- **macOS (Apple Silicon, MS2131, verified end-to-end)**: live sharp video + responsive control at 1080p and 720p, device unplug/HDMI-loss fallback, resolution changes, untick restore, packaged DMG signed and codesign-verified. Note: the MS2131 sustains uncompressed 1080p at ~20 fps on macOS (device/UVC-stack limit; 720p runs at 60 fps) — still a large quality win over MJPEG for KVM use.
- **Windows/Linux**: backends are compile-checked and follow standard ffmpeg dshow/v4l2 invocations, but **not yet validated on real hardware** — the device/mode parsing is the most likely thing to need adjustment. Happy to iterate if maintainers can test there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
